### PR TITLE
Implement ExcelSheet::writeFormula() and ExcelSheet::setTabRgbColor()

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -3,3 +3,4 @@
 Ilia Alshanetsky
 Jan Ehrhardt
 Darren Odden
+Xavier Perseguers

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 [2024-??-??] - Version 1.1.0dev
 	* Added new methods (requires LibXL 3.7.0)
 		- ExcelSheet::writeFormula()
+		- ExcelSheet::setTabRgbColor()
 
 [2018-??-??] - Version 1.0.3dev
 	* Fixed crash when trying to read an empty file

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+[2024-??-??] - Version 1.1.0dev
+	* Added new methods (requires LibXL 3.7.0)
+		- ExcelSheet::writeFormula()
+
 [2018-??-??] - Version 1.0.3dev
 	* Fixed crash when trying to read an empty file
 	* Fixed bug with writing references (see issue #234)

--- a/docs/ExcelAutoFilter.php
+++ b/docs/ExcelAutoFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
   +---------------------------------------------------------------------------+
   | ExcelAutoFilter                                                           |
@@ -11,97 +12,98 @@
   |                                                                           |
   +---------------------------------------------------------------------------+
 */
+
 class ExcelAutoFilter
 {
-	/**
-	* Create a AutoFilter within an Excel sheet
-	*
-	* @see ExcelSheet::autofilter()
-	* @param ExcelSheet $sheet
-	* @return ExcelAutoFilter
-	*/
-	public function __construct(ExcelSheet $sheet)
-	{
-	} // __construct
+    /**
+     * Create a AutoFilter within an Excel sheet
+     *
+     * @param ExcelSheet $sheet
+     * @return ExcelAutoFilter
+     * @see ExcelSheet::autofilter()
+     */
+    public function __construct(ExcelSheet $sheet)
+    {
+    } // __construct
 
-	/**
-	* Gets the cell range of AutoFilter with header.
-	*
-	* @return array with keys "row_first"(int), "row_last"(int), "col_first"(int), "col_last"(int)
-	*/
-	public function getRef()
-	{
-	} // getRef
+    /**
+     * Gets the cell range of AutoFilter with header.
+     *
+     * @return array with keys "row_first"(int), "row_last"(int), "col_first"(int), "col_last"(int)
+     */
+    public function getRef()
+    {
+    } // getRef
 
-	/**
-	* Sets the cell range of AutoFilter with header.
-	*
-	* @param int $row_first 0-based (optional, default = 0)
-	* @param int $row_last 0-based (optional, default = 0)
-	* @param int $col_first 0-based (optional, default = 0)
-	* @param int $col_last 0-based (optional, default = 0)
-	* @return void
-	*/
-	public function setRef($row_first = 0, $row_last = 0, $col_first = 0, $col_last = 0)
-	{
-	} // setRef
+    /**
+     * Sets the cell range of AutoFilter with header.
+     *
+     * @param int $row_first 0-based (optional, default = 0)
+     * @param int $row_last 0-based (optional, default = 0)
+     * @param int $col_first 0-based (optional, default = 0)
+     * @param int $col_last 0-based (optional, default = 0)
+     * @return void
+     */
+    public function setRef($row_first = 0, $row_last = 0, $col_first = 0, $col_last = 0)
+    {
+    } // setRef
 
-	/**
-	* Returns the AutoFilter column by zero-based index. Creates it if it doesn't exist.
-	*
-	* @param int $colId 0-based
-	* @return ExcelFilterColumn
-	*/
-	public function column($colId)
-	{
-	} // column
+    /**
+     * Returns the AutoFilter column by zero-based index. Creates it if it doesn't exist.
+     *
+     * @param int $colId 0-based
+     * @return ExcelFilterColumn
+     */
+    public function column($colId)
+    {
+    } // column
 
-	/**
-	* Returns the number of specified AutoFilter columns which have a filter information.
-	*
-	* @return int
-	*/
-	public function columnSize()
-	{
-	} // columnSize
+    /**
+     * Returns the number of specified AutoFilter columns which have a filter information.
+     *
+     * @return int
+     */
+    public function columnSize()
+    {
+    } // columnSize
 
-	/**
-	* Returns the specified AutoFilter column which have a filter information by index.
-	*
-	* @param int $index 0-based
-	* @return ExcelFilterColumn
-	*/
-	public function columnByIndex($index)
-	{
-	} // columnByIndex
+    /**
+     * Returns the specified AutoFilter column which have a filter information by index.
+     *
+     * @param int $index 0-based
+     * @return ExcelFilterColumn
+     */
+    public function columnByIndex($index)
+    {
+    } // columnByIndex
 
-	/**
-	* Gets the whole range of data to sort.
-	*
-	* @return array with keys "row_first"(int), "col_first"(int), "row_last"(int), "col_last"(int)
-	*/
-	public function getSortRange()
-	{
-	} // getSortRange
+    /**
+     * Gets the whole range of data to sort.
+     *
+     * @return array with keys "row_first"(int), "col_first"(int), "row_last"(int), "col_last"(int)
+     */
+    public function getSortRange()
+    {
+    } // getSortRange
 
-	/**
-	* Gets the zero-based index of sorted column in AutoFilter and its sort order.
-	*
-	* @return array with keys "column_index"(int), "descending"(bool),
-	*/
-	public function getSort()
-	{
-	} // getSort
+    /**
+     * Gets the zero-based index of sorted column in AutoFilter and its sort order.
+     *
+     * @return array with keys "column_index"(int), "descending"(bool),
+     */
+    public function getSort()
+    {
+    } // getSort
 
-	/**
-	* Sets the sorted column in AutoFilter by zero-based index and its sort order.
-	*
-	* @param int $columnIndex 0-based
-	* @param bool $descending
-	* @return bool
-	*/
-	public function setSort($columnIndex, $descending)
-	{
-	} // setSort
+    /**
+     * Sets the sorted column in AutoFilter by zero-based index and its sort order.
+     *
+     * @param int $columnIndex 0-based
+     * @param bool $descending
+     * @return bool
+     */
+    public function setSort($columnIndex, $descending)
+    {
+    } // setSort
 
 } // end ExcelAutoFilter

--- a/docs/ExcelBook.php
+++ b/docs/ExcelBook.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
   +---------------------------------------------------------------------------+
   | ExcelBook                                                                 |
@@ -12,544 +13,545 @@
   | Rob Gagnon <rgagnon24@gmail.com>                                          |
   +---------------------------------------------------------------------------+
 */
+
 class ExcelBook
 {
-	const PICTURETYPE_DIB = 3;
-	const PICTURETYPE_EMF = 4;
-	const PICTURETYPE_JPEG = 1;
-	const PICTURETYPE_PICT = 5;
-	const PICTURETYPE_PNG = 0;
-	const PICTURETYPE_TIFF = 6;
-	const PICTURETYPE_WMF = 2;
+    const PICTURETYPE_DIB = 3;
+    const PICTURETYPE_EMF = 4;
+    const PICTURETYPE_JPEG = 1;
+    const PICTURETYPE_PICT = 5;
+    const PICTURETYPE_PNG = 0;
+    const PICTURETYPE_TIFF = 6;
+    const PICTURETYPE_WMF = 2;
 
-	const SCOPE_UNDEFINED = -2;
-	const SCOPE_WORKBOOK = -1;
+    const SCOPE_UNDEFINED = -2;
+    const SCOPE_WORKBOOK = -1;
 
-	const SHEETTYPE_CHART = 1;
-	const SHEETTYPE_SHEET = 0;
-	const SHEETTYPE_UNKNOWN = 2;
+    const SHEETTYPE_CHART = 1;
+    const SHEETTYPE_SHEET = 0;
+    const SHEETTYPE_UNKNOWN = 2;
 
-	/**
-	* Create a new Excel workbook
-	*
-	* @param string $license_name (optional, default=null)
-	* @param string $license_key (optional, default=null)
-	* @param bool $excel_2007 (optional, default=false)
-	* @return ExcelBook
-	*/
-	public function __construct($license_name = null, $license_key = null, $excel_2007 = false)
-	{
-	} // __construct
+    /**
+     * Create a new Excel workbook
+     *
+     * @param string $license_name (optional, default=null)
+     * @param string $license_key (optional, default=null)
+     * @param bool $excel_2007 (optional, default=false)
+     * @return ExcelBook
+     */
+    public function __construct($license_name = null, $license_key = null, $excel_2007 = false)
+    {
+    } // __construct
 
-	/**
-	* Get or set the active Excel worksheet number
-	*
-	* @see ExcelBook::getActiveSheet()
-	* @see ExcelBook::setActiveSheet()
-	* @param int $sheet_number (optional, default=null) If supplied, the 0-based worksheet number to set as active
-	* @return int 0-based active worksheet number
-	*/
-	public function activeSheet($sheet_number = null)
-	{
-	} // activeSheet
+    /**
+     * Get or set the active Excel worksheet number
+     *
+     * @param int $sheet_number (optional, default=null) If supplied, the 0-based worksheet number to set as active
+     * @return int 0-based active worksheet number
+     * @see ExcelBook::getActiveSheet()
+     * @see ExcelBook::setActiveSheet()
+     */
+    public function activeSheet($sheet_number = null)
+    {
+    } // activeSheet
 
-	/**
-	* Create a custom cell format
-	*
-	* @see ExcelBook::getCustomFormat()
-	* @param string $format_string
-	* @return int The ID assigned to the new format
-	*/
-	public function addCustomFormat($format_string)
-	{
-	} // addCustomFormat
+    /**
+     * Create a custom cell format
+     *
+     * @param string $format_string
+     * @return int The ID assigned to the new format
+     * @see ExcelBook::getCustomFormat()
+     */
+    public function addCustomFormat($format_string)
+    {
+    } // addCustomFormat
 
-	/**
-	* Add or copy an ExcelFont object
-	*
-	* @param ExcelFont $font (optional, default=null) Font to copy
-	* @return ExcelFont
-	*/
-	public function addFont($font = null)
-	{
-	} // addFont
+    /**
+     * Add or copy an ExcelFont object
+     *
+     * @param ExcelFont $font (optional, default=null) Font to copy
+     * @return ExcelFont
+     */
+    public function addFont($font = null)
+    {
+    } // addFont
 
-	/**
-	* Add or copy an ExcelFormat object
-	*
-	* @param ExcelFormat $format (optional, default=null) Format to copy
-	* @return ExcelFormat
-	*/
-	public function addFormat(ExcelFormat $format = null)
-	{
-	} // addFormat
+    /**
+     * Add or copy an ExcelFormat object
+     *
+     * @param ExcelFormat $format (optional, default=null) Format to copy
+     * @return ExcelFormat
+     */
+    public function addFormat(ExcelFormat $format = null)
+    {
+    } // addFormat
 
-	/**
-	* Adds a picture to the workbook as link (only for xlsx files).
-	* Supports BMP, DIB, PNG, JPG and WMF picture formats. Use picture identifier with
-	* \ExcelSheet::setPictureDim() or \ExcelSheet::setPictureScale()
-	* @see \ExcelSheet::setPictureDim()
-	* @see \ExcelSheet::setPictureScale()
-	*
-	* @since libXl 3.8.0.0
-	* @param string $filename
-	* @param bool $insert (optional, default = false) false - stores only a link to file, true - stores a picture and a link to file.
-	* @return int picture identifier
-	*/
-	public function addPictureAsLink($filename, $insert = false)
-	{
-	} // addPictureAsLink
+    /**
+     * Adds a picture to the workbook as link (only for xlsx files).
+     * Supports BMP, DIB, PNG, JPG and WMF picture formats. Use picture identifier with
+     * \ExcelSheet::setPictureDim() or \ExcelSheet::setPictureScale()
+     * @param string $filename
+     * @param bool $insert (optional, default = false) false - stores only a link to file, true - stores a picture and a link to file.
+     * @return int picture identifier
+     * @see \ExcelSheet::setPictureDim()
+     * @see \ExcelSheet::setPictureScale()
+     *
+     * @since libXl 3.8.0.0
+     */
+    public function addPictureAsLink($filename, $insert = false)
+    {
+    } // addPictureAsLink
 
-	/**
-	* Add a picture from file
-	*
-	* @see ExcelBook::addPictureFromString()
-	* @see ExcelSheet::addPictureScaled()
-	* @see ExcelSheet::addPictureDim()
-	* @param string $filename
-	* @return int A picture ID
-	*/
-	public function addPictureFromFile($filename)
-	{
-	} // addPictureFromFile
+    /**
+     * Add a picture from file
+     *
+     * @param string $filename
+     * @return int A picture ID
+     * @see ExcelSheet::addPictureDim()
+     * @see ExcelBook::addPictureFromString()
+     * @see ExcelSheet::addPictureScaled()
+     */
+    public function addPictureFromFile($filename)
+    {
+    } // addPictureFromFile
 
-	/**
-	* Add a picture from string
-	*
-	* @see ExcelBook::addPictureFromFile()
-	* @see ExcelSheet::addPictureScaled()
-	* @see ExcelSheet::addPictureDim()
-	* @param string $data
-	* @return int A picture ID
-	*/
-	public function addPictureFromString($data)
-	{
-	} // addPictureFromString
+    /**
+     * Add a picture from string
+     *
+     * @param string $data
+     * @return int A picture ID
+     * @see ExcelSheet::addPictureDim()
+     * @see ExcelBook::addPictureFromFile()
+     * @see ExcelSheet::addPictureScaled()
+     */
+    public function addPictureFromString($data)
+    {
+    } // addPictureFromString
 
-	/**
-	* Add a worksheet to a workbook
-	*
-	* @param string $name The name for the new worksheet
-	* @return ExcelSheet The worksheet created
-	*/
-	public function addSheet($name)
-	{
-	} // addSheet
+    /**
+     * Add a worksheet to a workbook
+     *
+     * @param string $name The name for the new worksheet
+     * @return ExcelSheet The worksheet created
+     */
+    public function addSheet($name)
+    {
+    } // addSheet
 
-	/**
-	* Returns BIFF version of binary file. Used for xls format only.
-	*
-	* @return int BIFF version
-	*/
-	public function biffVersion()
-	{
-	} // biffVersion
+    /**
+     * Returns BIFF version of binary file. Used for xls format only.
+     *
+     * @return int BIFF version
+     */
+    public function biffVersion()
+    {
+    } // biffVersion
 
-	/**
-	* Packs red, green, and blue components in color value.  Used for xlsx format only.
-	*
-	* @see ExcelBook::colorUnpack()
-	* @param int $red
-	* @param int $green
-	* @param int $blue
-	* @return int
-	*/
-	public function colorPack($red, $green, $blue)
-	{
-	} // colorPack
+    /**
+     * Packs red, green, and blue components in color value.  Used for xlsx format only.
+     *
+     * @param int $red
+     * @param int $green
+     * @param int $blue
+     * @return int
+     * @see ExcelBook::colorUnpack()
+     */
+    public function colorPack($red, $green, $blue)
+    {
+    } // colorPack
 
-	/**
-	* Unpacks color value into red, green, and blue components.  Used for xlsx format only.
-	*
-	* @see ExcelBook::colorPack()
-	* @param int $color One of ExcelFormat::COLOR_* constants
-	* @return array with keys "red"(int), "green"(int), and "blue"(int)
-	*/
-	public function colorUnpack($color)
-	{
-	} // colorUnpack
+    /**
+     * Unpacks color value into red, green, and blue components.  Used for xlsx format only.
+     *
+     * @param int $color One of ExcelFormat::COLOR_* constants
+     * @return array with keys "red"(int), "green"(int), and "blue"(int)
+     * @see ExcelBook::colorPack()
+     */
+    public function colorUnpack($color)
+    {
+    } // colorUnpack
 
-	/**
-	* Create a copy of a worksheet in a workbook
-	*
-	* @param string $name The name for the new worksheet
-	* @param int $sheet_number The 0-based number of the source worksheet to copy
-	* @return ExcelSheet The worksheet created
-	*/
-	public function copySheet($name, $sheet_number)
-	{
-	} // copySheet
+    /**
+     * Create a copy of a worksheet in a workbook
+     *
+     * @param string $name The name for the new worksheet
+     * @param int $sheet_number The 0-based number of the source worksheet to copy
+     * @return ExcelSheet The worksheet created
+     */
+    public function copySheet($name, $sheet_number)
+    {
+    } // copySheet
 
-	/**
-	* Delete an Excel worksheet
-	*
-	* @param int $sheet_number 0-based worksheet number to delete
-	* @return bool True if sheet deleted, false if $sheet_number invalid
-	*/
-	public function deleteSheet($sheet_number)
-	{
-	} // deleteSheet
+    /**
+     * Delete an Excel worksheet
+     *
+     * @param int $sheet_number 0-based worksheet number to delete
+     * @return bool True if sheet deleted, false if $sheet_number invalid
+     */
+    public function deleteSheet($sheet_number)
+    {
+    } // deleteSheet
 
-	/**
-	* Get the active worksheet inside a workbook
-	*
-	* @see ExcelBook::activeSheet()
-	* @see ExcelBook::setActiveSheet()
-	* @return int 0-based active worksheet number
-	*/
-	public function getActiveSheet()
-	{
-	} // getActiveSheet
+    /**
+     * Get the active worksheet inside a workbook
+     *
+     * @return int 0-based active worksheet number
+     * @see ExcelBook::setActiveSheet()
+     * @see ExcelBook::activeSheet()
+     */
+    public function getActiveSheet()
+    {
+    } // getActiveSheet
 
-	/**
-	* Get an array of all ExcelFormat objects used inside a workbook
-	*
-	* @return array of ExcelFormat objects
-	*/
-	public function getAllFormats()
-	{
-	} // getAllFormats
+    /**
+     * Get an array of all ExcelFormat objects used inside a workbook
+     *
+     * @return array of ExcelFormat objects
+     */
+    public function getAllFormats()
+    {
+    } // getAllFormats
 
-	/**
-	* Get a custom cell format
-	*
-	* @see ExcelBook::addCustomFormat()
-	* @param int $id
-	* @return string
-	*/
-	public function getCustomFormat($id)
-	{
-	} // getCustomFormat
+    /**
+     * Get a custom cell format
+     *
+     * @param int $id
+     * @return string
+     * @see ExcelBook::addCustomFormat()
+     */
+    public function getCustomFormat($id)
+    {
+    } // getCustomFormat
 
-	/**
-	* Get the default font
-	*
-	* @see ExcelBook::setDefaultFont()
-	* @return array with keys "font"(string) and "font_size"(int)
-	*/
-	public function getDefaultFont()
-	{
-	} // getDefaultFont
+    /**
+     * Get the default font
+     *
+     * @return array with keys "font"(string) and "font_size"(int)
+     * @see ExcelBook::setDefaultFont()
+     */
+    public function getDefaultFont()
+    {
+    } // getDefaultFont
 
-	/**
-	* Get Excel error string
-	*
-	* @return string Description of last error that occurred, or false if no error
-	*/
-	public function getError()
-	{
-	} // getError
+    /**
+     * Get Excel error string
+     *
+     * @return string Description of last error that occurred, or false if no error
+     */
+    public function getError()
+    {
+    } // getError
 
-	/**
-	* Get LibXL version
-	*
-	* @return string LibXl library version
-	*/
-	public function getLibXlVersion()
-	{
-	} // getLibXlVersion
+    /**
+     * Get LibXL version
+     *
+     * @return string LibXl library version
+     */
+    public function getLibXlVersion()
+    {
+    } // getLibXlVersion
 
-	/**
-	* Returns a number of pictures in this workbook.
-	*
-	* @return int Number of pictures in Workbook
-	*/
-	public function getNumPictures()
-	{
-	} // getNumPictures
+    /**
+     * Returns a number of pictures in this workbook.
+     *
+     * @return int Number of pictures in Workbook
+     */
+    public function getNumPictures()
+    {
+    } // getNumPictures
 
-	/**
-	* Get PHP excel extension version
-	*
-	* @return string PHP Excel version
-	*/
-	public function getPhpExcelVersion()
-	{
-	} // getPhpExcelVersion
+    /**
+     * Get PHP excel extension version
+     *
+     * @return string PHP Excel version
+     */
+    public function getPhpExcelVersion()
+    {
+    } // getPhpExcelVersion
 
-	/**
-	* Returns a picture at position index.
-	*
-	* @param int $index
-	* @return array with keys "data"(string) and "type"(int)
-	*/
-	public function getPicture($index)
-	{
-	} // getPicture
+    /**
+     * Returns a picture at position index.
+     *
+     * @param int $index
+     * @return array with keys "data"(string) and "type"(int)
+     */
+    public function getPicture($index)
+    {
+    } // getPicture
 
-	/**
-	* Returns whether the R1C1 reference mode is active.
-	*
-	* @return bool
-	*/
-	public function getRefR1C1()
-	{
-	} // getRefR1C1
+    /**
+     * Returns whether the R1C1 reference mode is active.
+     *
+     * @return bool
+     */
+    public function getRefR1C1()
+    {
+    } // getRefR1C1
 
-	/**
-	* Get an Excel worksheet
-	*
-	* @param int $sheet_number (optional, default=0) 0-based worksheet number
-	* @return ExcelSheet or false if $sheet_number invalid
-	*/
-	public function getSheet($sheet_number = 0)
-	{
-	} // getSheet
+    /**
+     * Get an Excel worksheet
+     *
+     * @param int $sheet_number (optional, default=0) 0-based worksheet number
+     * @return ExcelSheet or false if $sheet_number invalid
+     */
+    public function getSheet($sheet_number = 0)
+    {
+    } // getSheet
 
-	/**
-	* Get an excel sheet by name.
-	*
-	* @param string $name
-	* @param bool $case_insensitive (optional, default=false)
-	* @return ExcelSheet
-	*/
-	public function getSheetByName($name, $case_insensitive = false)
-	{
-	} // getSheetByName
+    /**
+     * Get an excel sheet by name.
+     *
+     * @param string $name
+     * @param bool $case_insensitive (optional, default=false)
+     * @return ExcelSheet
+     */
+    public function getSheetByName($name, $case_insensitive = false)
+    {
+    } // getSheetByName
 
-	/**
-	* Inserts a new sheet to this book at position index, returns the sheet handle. Set initSheet
-	* to 0 if you wish to add a new empty sheet or use existing sheet's handle for copying.
-	*
-	* @param int $index
-	* @param string $name
-	* @param ExcelSheet $sheet (optional)
-	* @return ExcelSheet
-	*/
-	public function insertSheet($index, $name, $sheet = null)
-	{
-	} // insertSheet
+    /**
+     * Inserts a new sheet to this book at position index, returns the sheet handle. Set initSheet
+     * to 0 if you wish to add a new empty sheet or use existing sheet's handle for copying.
+     *
+     * @param int $index
+     * @param string $name
+     * @param ExcelSheet $sheet (optional)
+     * @return ExcelSheet
+     */
+    public function insertSheet($index, $name, $sheet = null)
+    {
+    } // insertSheet
 
-	/**
-	* Returns whether the 1904 date system is active:
-	* true - 1904 date system,
-	* false - 1900 date system
-	*
-	* @return bool
-	*/
-	public function isDate1904()
-	{
-	} // isDate1904
+    /**
+     * Returns whether the 1904 date system is active:
+     * true - 1904 date system,
+     * false - 1900 date system
+     *
+     * @return bool
+     */
+    public function isDate1904()
+    {
+    } // isDate1904
 
-	/**
-	* Returns whether the workbook is a template.
-	*
-	* @return bool
-	*/
-	public function isTemplate()
-	{
-	} // isTemplate
+    /**
+     * Returns whether the workbook is a template.
+     *
+     * @return bool
+     */
+    public function isTemplate()
+    {
+    } // isTemplate
 
-	/**
-	* Load Excel data string
-	*
-	* @param string $data
-	* @return bool
-	*/
-	public function load($data)
-	{
-	} // load
+    /**
+     * Load Excel data string
+     *
+     * @param string $data
+     * @return bool
+     */
+    public function load($data)
+    {
+    } // load
 
-	/**
-	* Load Excel from file
-	*
-	* @param string $filename
-	* @return bool
-	*/
-	public function loadFile($filename)
-	{
-	} // loadFile
+    /**
+     * Load Excel from file
+     *
+     * @param string $filename
+     * @return bool
+     */
+    public function loadFile($filename)
+    {
+    } // loadFile
 
-	/**
-	* Load Excel sheet info
-	*
-	* @param string $filename
-	* @return bool
-	*/
-	public function loadInfo($filename)
-	{
-	} // loadInfo
+    /**
+     * Load Excel sheet info
+     *
+     * @param string $filename
+     * @return bool
+     */
+    public function loadInfo($filename)
+    {
+    } // loadInfo
 
-	/**
-	* Moves a sheet with specified index to a new position. Returns false if error occurs.
-	*
-	* @since libXL 3.8.0.0
-	* @param int $srcIndex
-	* @param int $dstIndex
-	* @return bool
-	*/
-	public function moveSheet($srcIndex, $dstIndex)
-	{
-	} // moveSheet
+    /**
+     * Moves a sheet with specified index to a new position. Returns false if error occurs.
+     *
+     * @param int $srcIndex
+     * @param int $dstIndex
+     * @return bool
+     * @since libXL 3.8.0.0
+     */
+    public function moveSheet($srcIndex, $dstIndex)
+    {
+    } // moveSheet
 
-	/**
-	* Pack a unix timestamp into an Excel double
-	*
-	* @see ExcelBook::unpackDate()
-	* @param int $timestamp
-	* @return float
-	*/
-	public function packDate($timestamp)
-	{
-	} // packDate
+    /**
+     * Pack a unix timestamp into an Excel double
+     *
+     * @param int $timestamp
+     * @return float
+     * @see ExcelBook::unpackDate()
+     */
+    public function packDate($timestamp)
+    {
+    } // packDate
 
-	/**
-	* Pack a date from single values into an Excel double
-	*
-	* with year=0, month=0 and day=0 you can generate a time-only value
-	* - if you click on a cell with time-format, in the "formula bar" will appear a time only (without date)
-	*
-	* @param int $year
-	* @param int $month
-	* @param int $day
-	* @param int $hour
-	* @param int $minute
-	* @param int $second
-	* @return float
-	*/
-	public function packDateValues($year, $month, $day, $hour, $minute, $second)
-	{
-	} // packDateValues
+    /**
+     * Pack a date from single values into an Excel double
+     *
+     * with year=0, month=0 and day=0 you can generate a time-only value
+     * - if you click on a cell with time-format, in the "formula bar" will appear a time only (without date)
+     *
+     * @param int $year
+     * @param int $month
+     * @param int $day
+     * @param int $hour
+     * @param int $minute
+     * @param int $second
+     * @return float
+     */
+    public function packDateValues($year, $month, $day, $hour, $minute, $second)
+    {
+    } // packDateValues
 
-	/**
-	* Returns whether RGB mode is active
-	*
-	* @see ExcelBook::setRGBMode()
-	* @return bool
-	*/
-	public function rgbMode()
-	{
-	} // rgbMode
+    /**
+     * Returns whether RGB mode is active
+     *
+     * @return bool
+     * @see ExcelBook::setRGBMode()
+     */
+    public function rgbMode()
+    {
+    } // rgbMode
 
-	/**
-	* Save Excel file
-	*
-	* @param string $filename (optional, default=null)
-	* @return mixed If $filename is null, returns string, otherwise returns bool true if OK, false if not
-	*/
-	public function save($filename = null)
-	{
-	} // save
+    /**
+     * Save Excel file
+     *
+     * @param string $filename (optional, default=null)
+     * @return mixed If $filename is null, returns string, otherwise returns bool true if OK, false if not
+     */
+    public function save($filename = null)
+    {
+    } // save
 
-	/**
-	* Set the active worksheet
-	*
-	* @see ExcelBook::getActiveSheet()
-	* @see ExcelBook::activeSheet()
-	* @param int $sheet_number 0-based worksheet to make active
-	* @return bool
-	*/
-	public function setActiveSheet($sheet_number)
-	{
-	} // setActiveSheet
+    /**
+     * Set the active worksheet
+     *
+     * @param int $sheet_number 0-based worksheet to make active
+     * @return bool
+     * @see ExcelBook::getActiveSheet()
+     * @see ExcelBook::activeSheet()
+     */
+    public function setActiveSheet($sheet_number)
+    {
+    } // setActiveSheet
 
-	/**
-	* Sets the date system mode:
-	* true - 1904 date system,
-	* false - 1900 date system (default)
-	*
-	* @param bool $date_type
-	* @return bool
-	*/
-	public function setDate1904($date_type)
-	{
-	} // setDate1904
+    /**
+     * Sets the date system mode:
+     * true - 1904 date system,
+     * false - 1900 date system (default)
+     *
+     * @param bool $date_type
+     * @return bool
+     */
+    public function setDate1904($date_type)
+    {
+    } // setDate1904
 
-	/**
-	* Set the default font and size
-	*
-	* @see ExcelBook::getDefaultFont()
-	* @param string $font_name
-	* @param string $font_size
-	* @return void
-	*/
-	public function setDefaultFont($font_name, $font_size)
-	{
-	} // setDefaultFont
+    /**
+     * Set the default font and size
+     *
+     * @param string $font_name
+     * @param string $font_size
+     * @return void
+     * @see ExcelBook::getDefaultFont()
+     */
+    public function setDefaultFont($font_name, $font_size)
+    {
+    } // setDefaultFont
 
-	/**
-	* Set the locale<br>
-	* possible values: '.1252' (Windows-1252 or Cp1252), '.OCP' (OEM CodePage), default: '.ACP' (ANSI CodePage) if empty
-	*
-	* @param string $locale
-	* @return void
-	*/
-	public function setLocale($locale)
-	{
-	} // setLocale
+    /**
+     * Set the locale<br>
+     * possible values: '.1252' (Windows-1252 or Cp1252), '.OCP' (OEM CodePage), default: '.ACP' (ANSI CodePage) if empty
+     *
+     * @param string $locale
+     * @return void
+     */
+    public function setLocale($locale)
+    {
+    } // setLocale
 
-	/**
-	* Sets the R1C1 reference mode.
-	*
-	* @param bool $active
-	* @return void
-	*/
-	public function setRefR1C1($active)
-	{
-	} // setRefR1C1
+    /**
+     * Sets the R1C1 reference mode.
+     *
+     * @param bool $active
+     * @return void
+     */
+    public function setRefR1C1($active)
+    {
+    } // setRefR1C1
 
-	/**
-	* Sets RGB mode on or off
-	*
-	* @see ExcelBook::rgbMode()
-	* @param bool $mode
-	* @return void
-	*/
-	public function setRGBMode($mode)
-	{
-	} // setRGBMode
+    /**
+     * Sets RGB mode on or off
+     *
+     * @param bool $mode
+     * @return void
+     * @see ExcelBook::rgbMode()
+     */
+    public function setRGBMode($mode)
+    {
+    } // setRGBMode
 
-	/**
-	* Sets the template flag, if the workbook is template.
-	*
-	* @param bool $mode
-	* @return void
-	*/
-	public function setTemplate($mode)
-	{
-	} // setTemplate
+    /**
+     * Sets the template flag, if the workbook is template.
+     *
+     * @param bool $mode
+     * @return void
+     */
+    public function setTemplate($mode)
+    {
+    } // setTemplate
 
-	/**
-	* Get the number of worksheets inside a workbook
-	*
-	* @return int
-	*/
-	public function sheetCount()
-	{
-	} // sheetCount
+    /**
+     * Get the number of worksheets inside a workbook
+     *
+     * @return int
+     */
+    public function sheetCount()
+    {
+    } // sheetCount
 
-	/**
-	* Returns the sheet name by index
-	*
-	* @param int $index
-	* @return string
-	*/
-	public function getSheetName($index)
-	{
-	} // getSheetName
+    /**
+     * Returns the sheet name by index
+     *
+     * @param int $index
+     * @return string
+     */
+    public function getSheetName($index)
+    {
+    } // getSheetName
 
-	/**
-	* Returns type of sheet with specified index:
-	* 0 - sheet
-	* 1 - chart
-	* 2 - unknown
-	*
-	* @param int $sheet
-	* @return int
-	*/
-	public function sheetType($sheet)
-	{
-	} // sheetType
+    /**
+     * Returns type of sheet with specified index:
+     * 0 - sheet
+     * 1 - chart
+     * 2 - unknown
+     *
+     * @param int $sheet
+     * @return int
+     */
+    public function sheetType($sheet)
+    {
+    } // sheetType
 
-	/**
-	* Unpack an Excel double into a unix timestamp
-	*
-	* @see ExcelBook::packDate()
-	* @param float $date
-	* @return int
-	*/
-	public function unpackDate($date)
-	{
-	} // unpackDate
+    /**
+     * Unpack an Excel double into a unix timestamp
+     *
+     * @param float $date
+     * @return int
+     * @see ExcelBook::packDate()
+     */
+    public function unpackDate($date)
+    {
+    } // unpackDate
 
 } // end ExcelBook

--- a/docs/ExcelFilterColumn.php
+++ b/docs/ExcelFilterColumn.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
   +---------------------------------------------------------------------------+
   | ExcelFilterColumn                                                         |
@@ -11,133 +12,134 @@
   |                                                                           |
   +---------------------------------------------------------------------------+
 */
+
 class ExcelFilterColumn
 {
-	const FILTER_VALUE = 0;
-	const FILTER_TOP10 = 1;
-	const FILTER_CUSTOM = 2;
-	const FILTER_DYNAMIC = 3;
-	const FILTER_COLOR = 4;
-	const FILTER_ICON = 5;
-	const FILTER_EXT = 6;
-	const FILTER_NOT_SET = 7;
+    const FILTER_VALUE = 0;
+    const FILTER_TOP10 = 1;
+    const FILTER_CUSTOM = 2;
+    const FILTER_DYNAMIC = 3;
+    const FILTER_COLOR = 4;
+    const FILTER_ICON = 5;
+    const FILTER_EXT = 6;
+    const FILTER_NOT_SET = 7;
 
-	const OPERATOR_EQUAL = 0;
-	const OPERATOR_GREATER_THAN = 1;
-	const OPERATOR_GREATER_THAN_OR_EQUAL = 2;
-	const OPERATOR_LESS_THAN = 3;
-	const OPERATOR_LESS_THAN_OR_EQUAL = 4;
-	const OPERATOR_NOT_EQUAL = 5;
+    const OPERATOR_EQUAL = 0;
+    const OPERATOR_GREATER_THAN = 1;
+    const OPERATOR_GREATER_THAN_OR_EQUAL = 2;
+    const OPERATOR_LESS_THAN = 3;
+    const OPERATOR_LESS_THAN_OR_EQUAL = 4;
+    const OPERATOR_NOT_EQUAL = 5;
 
-	/**
-	* Create a filter column within an Excel auto filter
-	*
-	* @see ExcelAutoFilter::column()
-	* @param ExcelAutoFilter $autoFilter
-	* @return ExcelFilterColumn
-	*/
-	public function __construct(ExcelAutoFilter $autoFilter)
-	{
-	} // __construct
+    /**
+     * Create a filter column within an Excel auto filter
+     *
+     * @param ExcelAutoFilter $autoFilter
+     * @return ExcelFilterColumn
+     * @see ExcelAutoFilter::column()
+     */
+    public function __construct(ExcelAutoFilter $autoFilter)
+    {
+    } // __construct
 
-	/**
-	* Returns the zero-based index of this AutoFilter column.
-	*
-	* @return int
-	*/
-	public function index()
-	{
-	} // index
+    /**
+     * Returns the zero-based index of this AutoFilter column.
+     *
+     * @return int
+     */
+    public function index()
+    {
+    } // index
 
-	/**
-	* Returns the filter type of this AutoFilter column.
-	*
-	* @return int One of ExcelFilterColumn::FILTER_* constants
-	*/
-	public function filterType()
-	{
-	} // filterType
+    /**
+     * Returns the filter type of this AutoFilter column.
+     *
+     * @return int One of ExcelFilterColumn::FILTER_* constants
+     */
+    public function filterType()
+    {
+    } // filterType
 
-	/**
-	* Returns the number of filter values.
-	*
-	* @return int
-	*/
-	public function filterSize()
-	{
-	} // filterSize
+    /**
+     * Returns the number of filter values.
+     *
+     * @return int
+     */
+    public function filterSize()
+    {
+    } // filterSize
 
-	/**
-	* Returns the filter value by index.
-	*
-	* @param int $index
-	* @return string filter value
-	*/
-	public function filter($index)
-	{
-	} // filter
+    /**
+     * Returns the filter value by index.
+     *
+     * @param int $index
+     * @return string filter value
+     */
+    public function filter($index)
+    {
+    } // filter
 
-	/**
-	* Adds the filter value.
-	*
-	* @param string $filterValue
-	* @return void
-	*/
-	public function addFilter($filterValue)
-	{
-	} // addFilter
+    /**
+     * Adds the filter value.
+     *
+     * @param string $filterValue
+     * @return void
+     */
+    public function addFilter($filterValue)
+    {
+    } // addFilter
 
-	/**
-	* Gets the number of top or bottom items:
-	*
-	* @return array with keys "value"(float), "top"(bool) and "percent"(bool)
-	*/
-	public function getTop10()
-	{
-	} // getTop10
+    /**
+     * Gets the number of top or bottom items:
+     *
+     * @return array with keys "value"(float), "top"(bool) and "percent"(bool)
+     */
+    public function getTop10()
+    {
+    } // getTop10
 
-	/**
-	* Sets the number of top or bottom items:
-	*
-	* @param float $value - number of items;
-	* @param bool $top - top items if true otherwise bottom items; (optional, default = true)
-	* @param bool $percent - using percent instead of number items. (optional, default = false)
-	* @return bool
-	*/
-	public function setTop10($value, $top = true, $percent = false)
-	{
-	} // setTop10
+    /**
+     * Sets the number of top or bottom items:
+     *
+     * @param float $value - number of items;
+     * @param bool $top - top items if true otherwise bottom items; (optional, default = true)
+     * @param bool $percent - using percent instead of number items. (optional, default = false)
+     * @return bool
+     */
+    public function setTop10($value, $top = true, $percent = false)
+    {
+    } // setTop10
 
-	/**
-	* Gets the custom filter criteria:
-	*
-	* @return array with keys "operator_1"(int), "value_1"(string), "operator_2"(int), "value_2"(string) and "andOp"(bool)
-	*/
-	public function getCustomFilter()
-	{
-	} // getCustomFilter
+    /**
+     * Gets the custom filter criteria:
+     *
+     * @return array with keys "operator_1"(int), "value_1"(string), "operator_2"(int), "value_2"(string) and "andOp"(bool)
+     */
+    public function getCustomFilter()
+    {
+    } // getCustomFilter
 
-	/**
-	* Sets the custom filter criteria.
-	*
-	* @param int $op1 - one of ExcelFilterColumn::OPERATOR_* constants - operator used by the filter comparison in the first filter criteria;
-	* @param string $v1 - value used in the first filter criteria;
-	* @param int $op2 - one of ExcelFilterColumn::OPERATOR_* constants - operator used by the filter comparison in the second filter criteria; (optional, default = -1)
-	* @param string $v2 - value used in the second filter criteria; (optional, default = null)
-	* @param bool $andOp - flag indicating whether the two criterias have an "and" relationship. True indicates "and", false indicates "or". (optional, default = false)
-	* @return void
-	*/
-	public function setCustomFilter($op1, $v1, $op2 = -1, $v2 = null, $andOp = false)
-	{
-	} // setCustomFilter
+    /**
+     * Sets the custom filter criteria.
+     *
+     * @param int $op1 - one of ExcelFilterColumn::OPERATOR_* constants - operator used by the filter comparison in the first filter criteria;
+     * @param string $v1 - value used in the first filter criteria;
+     * @param int $op2 - one of ExcelFilterColumn::OPERATOR_* constants - operator used by the filter comparison in the second filter criteria; (optional, default = -1)
+     * @param string $v2 - value used in the second filter criteria; (optional, default = null)
+     * @param bool $andOp - flag indicating whether the two criterias have an "and" relationship. True indicates "and", false indicates "or". (optional, default = false)
+     * @return void
+     */
+    public function setCustomFilter($op1, $v1, $op2 = -1, $v2 = null, $andOp = false)
+    {
+    } // setCustomFilter
 
-	/**
-	* Clear the filter criteria.
-	*
-	* @return bool
-	*/
-	public function clear()
-	{
-	} // clear
+    /**
+     * Clear the filter criteria.
+     *
+     * @return bool
+     */
+    public function clear()
+    {
+    } // clear
 
 } // end ExcelFilterColumn

--- a/docs/ExcelFont.php
+++ b/docs/ExcelFont.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
   +---------------------------------------------------------------------------+
   | ExcelFont                                                                 |
@@ -12,107 +13,108 @@
   | Rob Gagnon <rgagnon24@gmail.com>                                          |
   +---------------------------------------------------------------------------+
 */
+
 class ExcelFont
 {
-	const NORMAL = 0;
-	const SUPERSCRIPT = 1;
-	const SUBSCRIPT = 2;
+    const NORMAL = 0;
+    const SUPERSCRIPT = 1;
+    const SUBSCRIPT = 2;
 
-	const UNDERLINE_NONE = 0;
-	const UNDERLINE_SINGLE = 1;
-	const UNDERLINE_DOUBLE = 2;
-	const UNDERLINE_SINGLEACC = 33;
-	const UNDERLINE_DOUBLEACC = 34;
+    const UNDERLINE_NONE = 0;
+    const UNDERLINE_SINGLE = 1;
+    const UNDERLINE_DOUBLE = 2;
+    const UNDERLINE_SINGLEACC = 33;
+    const UNDERLINE_DOUBLEACC = 34;
 
-	/**
-	* Create a font within an Excel workbook
-	*
-	* @see ExcelBook::addFont()
-	* @param ExcelBook $book
-	* @return ExcelFont
-	*/
-	public function __construct(ExcelBook $book)
-	{
-	} // __construct
+    /**
+     * Create a font within an Excel workbook
+     *
+     * @param ExcelBook $book
+     * @return ExcelFont
+     * @see ExcelBook::addFont()
+     */
+    public function __construct(ExcelBook $book)
+    {
+    } // __construct
 
-	/**
-	* Get, or set if bold is on or off
-	*
-	* @param bool $bold (optional, default=null)
-	* @return bool
-	*/
-	public function bold($bold = null)
-	{
-	} // bold
+    /**
+     * Get, or set if bold is on or off
+     *
+     * @param bool $bold (optional, default=null)
+     * @return bool
+     */
+    public function bold($bold = null)
+    {
+    } // bold
 
-	/**
-	* Get, or set the font color
-	*
-	* @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
-	* @return int
-	*/
-	public function color($color = null)
-	{
-	} // color
+    /**
+     * Get, or set the font color
+     *
+     * @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
+     * @return int
+     */
+    public function color($color = null)
+    {
+    } // color
 
-	/**
-	* Get, or set if italics are on or off
-	*
-	* @param bool $italics (optional, default=null)
-	* @return bool
-	*/
-	public function italics($italics = null)
-	{
-	} // italics
+    /**
+     * Get, or set if italics are on or off
+     *
+     * @param bool $italics (optional, default=null)
+     * @return bool
+     */
+    public function italics($italics = null)
+    {
+    } // italics
 
-	/**
-	* Get, or set the font script mode
-	*
-	* @param int $mode (optional, default=null) One of ExcelFont::NORMAL, ::SUBSCRIPT, or ::SUPERSCRIPT
-	* @return int
-	*/
-	public function mode($mode = null)
-	{
-	} // mode
+    /**
+     * Get, or set the font script mode
+     *
+     * @param int $mode (optional, default=null) One of ExcelFont::NORMAL, ::SUBSCRIPT, or ::SUPERSCRIPT
+     * @return int
+     */
+    public function mode($mode = null)
+    {
+    } // mode
 
-	/**
-	* Get, or set the font name
-	*
-	* @param string $font_name (optional, default=null)
-	* @return string
-	*/
-	public function name($font_name = null)
-	{
-	} // name
+    /**
+     * Get, or set the font name
+     *
+     * @param string $font_name (optional, default=null)
+     * @return string
+     */
+    public function name($font_name = null)
+    {
+    } // name
 
-	/**
-	* Get, or set the font size
-	*
-	* @param int $size (optional, default=null)
-	* @return int The current font size
-	*/
-	public function size($size = null)
-	{
-	} // size
+    /**
+     * Get, or set the font size
+     *
+     * @param int $size (optional, default=null)
+     * @return int The current font size
+     */
+    public function size($size = null)
+    {
+    } // size
 
-	/**
-	* Get, or set if strike-through is on or off
-	*
-	* @param bool $strike (optional, default=null)
-	* @return bool
-	*/
-	public function strike($strike = null)
-	{
-	} // strike
+    /**
+     * Get, or set if strike-through is on or off
+     *
+     * @param bool $strike (optional, default=null)
+     * @return bool
+     */
+    public function strike($strike = null)
+    {
+    } // strike
 
-	/**
-	* Get, or set the underline style
-	*
-	* @param int $underline (optional, default=null) One of ExcelFont::UNDERLINE_* constants
-	* @return int
-	*/
-	public function underline($underline = null)
-	{
-	} // underline
+    /**
+     * Get, or set the underline style
+     *
+     * @param int $underline (optional, default=null) One of ExcelFont::UNDERLINE_* constants
+     * @return int
+     */
+    public function underline($underline = null)
+    {
+    } // underline
 
 } // end ExcelFont

--- a/docs/ExcelFormat.php
+++ b/docs/ExcelFormat.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
   +---------------------------------------------------------------------------+
   | ExcelFormat                                                               |
@@ -12,434 +13,436 @@
   | Rob Gagnon <rgagnon24@gmail.com>                                          |
   +---------------------------------------------------------------------------+
 */
+
 class ExcelFormat
 {
-	const COLOR_BLACK = 8;
-	const COLOR_WHITE = 9;
-	const COLOR_RED = 10;
-	const COLOR_BRIGHTGREEN = 11;
-	const COLOR_BLUE = 12;
-	const COLOR_YELLOW = 13;
-	const COLOR_PINK = 14;
-	const COLOR_TURQUOISE = 15;
-	const COLOR_DARKRED = 16;
-	const COLOR_GREEN = 17;
-	const COLOR_DARKBLUE = 18;
-	const COLOR_DARKYELLOW = 19;
-	const COLOR_VIOLET = 20;
-	const COLOR_TEAL = 21;
-	const COLOR_GRAY25 = 22;
-	const COLOR_GRAY50 = 23;
-	const COLOR_PERIWINKLE_CF = 24;
-	const COLOR_PLUM_CF = 25;
-	const COLOR_IVORY_CF = 26;
-	const COLOR_LIGHTTURQUOISE_CF = 27;
-	const COLOR_DARKPURPLE_CF = 28;
-	const COLOR_CORAL_CF = 29;
-	const COLOR_OCEANBLUE_CF = 30;
-	const COLOR_ICEBLUE_CF = 31;
-	const COLOR_DARKBLUE_CL = 32;
-	const COLOR_PINK_CL = 33;
-	const COLOR_YELLOW_CL = 34;
-	const COLOR_TURQUOISE_CL = 35;
-	const COLOR_VIOLET_CL = 36;
-	const COLOR_DARKRED_CL = 37;
-	const COLOR_TEAL_CL = 38;
-	const COLOR_BLUE_CL = 39;
-	const COLOR_SKYBLUE = 40;
-	const COLOR_LIGHTTURQUOISE = 41;
-	const COLOR_LIGHTGREEN = 42;
-	const COLOR_LIGHTYELLOW = 43;
-	const COLOR_PALEBLUE = 44;
-	const COLOR_ROSE = 45;
-	const COLOR_LAVENDER = 46;
-	const COLOR_TAN = 47;
-	const COLOR_LIGHTBLUE = 48;
-	const COLOR_AQUA = 49;
-	const COLOR_LIME = 50;
-	const COLOR_GOLD = 51;
-	const COLOR_LIGHTORANGE = 52;
-	const COLOR_ORANGE = 53;
-	const COLOR_BLUEGRAY = 54;
-	const COLOR_GRAY40 = 55;
-	const COLOR_DARKTEAL = 56;
-	const COLOR_SEAGREEN = 57;
-	const COLOR_DARKGREEN = 58;
-	const COLOR_OLIVEGREEN = 59;
-	const COLOR_BROWN = 60;
-	const COLOR_PLUM = 61;
-	const COLOR_INDIGO = 62;
-	const COLOR_GRAY80 = 63;
-	const COLOR_DEFAULT_FOREGROUND = 64;
-	const COLOR_DEFAULT_BACKGROUND = 65;
+    const COLOR_BLACK = 8;
+    const COLOR_WHITE = 9;
+    const COLOR_RED = 10;
+    const COLOR_BRIGHTGREEN = 11;
+    const COLOR_BLUE = 12;
+    const COLOR_YELLOW = 13;
+    const COLOR_PINK = 14;
+    const COLOR_TURQUOISE = 15;
+    const COLOR_DARKRED = 16;
+    const COLOR_GREEN = 17;
+    const COLOR_DARKBLUE = 18;
+    const COLOR_DARKYELLOW = 19;
+    const COLOR_VIOLET = 20;
+    const COLOR_TEAL = 21;
+    const COLOR_GRAY25 = 22;
+    const COLOR_GRAY50 = 23;
+    const COLOR_PERIWINKLE_CF = 24;
+    const COLOR_PLUM_CF = 25;
+    const COLOR_IVORY_CF = 26;
+    const COLOR_LIGHTTURQUOISE_CF = 27;
+    const COLOR_DARKPURPLE_CF = 28;
+    const COLOR_CORAL_CF = 29;
+    const COLOR_OCEANBLUE_CF = 30;
+    const COLOR_ICEBLUE_CF = 31;
+    const COLOR_DARKBLUE_CL = 32;
+    const COLOR_PINK_CL = 33;
+    const COLOR_YELLOW_CL = 34;
+    const COLOR_TURQUOISE_CL = 35;
+    const COLOR_VIOLET_CL = 36;
+    const COLOR_DARKRED_CL = 37;
+    const COLOR_TEAL_CL = 38;
+    const COLOR_BLUE_CL = 39;
+    const COLOR_SKYBLUE = 40;
+    const COLOR_LIGHTTURQUOISE = 41;
+    const COLOR_LIGHTGREEN = 42;
+    const COLOR_LIGHTYELLOW = 43;
+    const COLOR_PALEBLUE = 44;
+    const COLOR_ROSE = 45;
+    const COLOR_LAVENDER = 46;
+    const COLOR_TAN = 47;
+    const COLOR_LIGHTBLUE = 48;
+    const COLOR_AQUA = 49;
+    const COLOR_LIME = 50;
+    const COLOR_GOLD = 51;
+    const COLOR_LIGHTORANGE = 52;
+    const COLOR_ORANGE = 53;
+    const COLOR_BLUEGRAY = 54;
+    const COLOR_GRAY40 = 55;
+    const COLOR_DARKTEAL = 56;
+    const COLOR_SEAGREEN = 57;
+    const COLOR_DARKGREEN = 58;
+    const COLOR_OLIVEGREEN = 59;
+    const COLOR_BROWN = 60;
+    const COLOR_PLUM = 61;
+    const COLOR_INDIGO = 62;
+    const COLOR_GRAY80 = 63;
+    const COLOR_DEFAULT_FOREGROUND = 64;
+    const COLOR_DEFAULT_BACKGROUND = 65;
 
-	const AS_DATE = 1;
-	const AS_FORMULA = 2;
-	const AS_NUMERIC_STRING = 3;
+    const AS_DATE = 1;
+    const AS_FORMULA = 2;
+    const AS_NUMERIC_STRING = 3;
 
-	const NUMFORMAT_GENERAL = 0;
-	const NUMFORMAT_NUMBER = 1;
-	const NUMFORMAT_NUMBER_D2 = 2;
-	const NUMFORMAT_NUMBER_SEP = 3;
-	const NUMFORMAT_NUMBER_SEP_D2 = 4;
-	const NUMFORMAT_CURRENCY_NEGBRA = 5;
-	const NUMFORMAT_CURRENCY_NEGBRARED = 6;
-	const NUMFORMAT_CURRENCY_D2_NEGBRA = 7;
-	const NUMFORMAT_CURRENCY_D2_NEGBRARED = 8;
-	const NUMFORMAT_PERCENT = 9;
-	const NUMFORMAT_PERCENT_D2 = 10;
-	const NUMFORMAT_SCIENTIFIC_D2 = 11;
-	const NUMFORMAT_FRACTION_ONEDIG = 12;
-	const NUMFORMAT_FRACTION_TWODIG = 13;
-	const NUMFORMAT_DATE = 14;
-	const NUMFORMAT_CUSTOM_D_MON_YY = 15;
-	const NUMFORMAT_CUSTOM_D_MON = 16;
-	const NUMFORMAT_CUSTOM_MON_YY = 17;
-	const NUMFORMAT_CUSTOM_HMM_AM = 18;
-	const NUMFORMAT_CUSTOM_HMMSS_AM = 19;
-	const NUMFORMAT_CUSTOM_HMM = 20;
-	const NUMFORMAT_CUSTOM_HMMSS = 21;
-	const NUMFORMAT_CUSTOM_MDYYYY_HMM = 22;
-	const NUMFORMAT_NUMBER_SEP_NEGBRA = 37;
-	const NUMFORMAT_NUMBER_SEP_NEGBRARED = 38;
-	const NUMFORMAT_NUMBER_D2_SEP_NEGBRA = 39;
-	const NUMFORMAT_NUMBER_D2_SEP_NEGBRARED = 40;
-	const NUMFORMAT_ACCOUNT = 41;
-	const NUMFORMAT_ACCOUNTCUR = 42;
-	const NUMFORMAT_ACCOUNT_D2 = 43;
-	const NUMFORMAT_ACCOUNT_D2_CUR = 44;
-	const NUMFORMAT_CUSTOM_MMSS = 45;
-	const NUMFORMAT_CUSTOM_H0MMSS = 46;
-	const NUMFORMAT_CUSTOM_MMSS0 = 47;
-	const NUMFORMAT_CUSTOM_000P0E_PLUS0 = 48;
-	const NUMFORMAT_TEXT = 49;
+    const NUMFORMAT_GENERAL = 0;
+    const NUMFORMAT_NUMBER = 1;
+    const NUMFORMAT_NUMBER_D2 = 2;
+    const NUMFORMAT_NUMBER_SEP = 3;
+    const NUMFORMAT_NUMBER_SEP_D2 = 4;
+    const NUMFORMAT_CURRENCY_NEGBRA = 5;
+    const NUMFORMAT_CURRENCY_NEGBRARED = 6;
+    const NUMFORMAT_CURRENCY_D2_NEGBRA = 7;
+    const NUMFORMAT_CURRENCY_D2_NEGBRARED = 8;
+    const NUMFORMAT_PERCENT = 9;
+    const NUMFORMAT_PERCENT_D2 = 10;
+    const NUMFORMAT_SCIENTIFIC_D2 = 11;
+    const NUMFORMAT_FRACTION_ONEDIG = 12;
+    const NUMFORMAT_FRACTION_TWODIG = 13;
+    const NUMFORMAT_DATE = 14;
+    const NUMFORMAT_CUSTOM_D_MON_YY = 15;
+    const NUMFORMAT_CUSTOM_D_MON = 16;
+    const NUMFORMAT_CUSTOM_MON_YY = 17;
+    const NUMFORMAT_CUSTOM_HMM_AM = 18;
+    const NUMFORMAT_CUSTOM_HMMSS_AM = 19;
+    const NUMFORMAT_CUSTOM_HMM = 20;
+    const NUMFORMAT_CUSTOM_HMMSS = 21;
+    const NUMFORMAT_CUSTOM_MDYYYY_HMM = 22;
+    const NUMFORMAT_NUMBER_SEP_NEGBRA = 37;
+    const NUMFORMAT_NUMBER_SEP_NEGBRARED = 38;
+    const NUMFORMAT_NUMBER_D2_SEP_NEGBRA = 39;
+    const NUMFORMAT_NUMBER_D2_SEP_NEGBRARED = 40;
+    const NUMFORMAT_ACCOUNT = 41;
+    const NUMFORMAT_ACCOUNTCUR = 42;
+    const NUMFORMAT_ACCOUNT_D2 = 43;
+    const NUMFORMAT_ACCOUNT_D2_CUR = 44;
+    const NUMFORMAT_CUSTOM_MMSS = 45;
+    const NUMFORMAT_CUSTOM_H0MMSS = 46;
+    const NUMFORMAT_CUSTOM_MMSS0 = 47;
+    const NUMFORMAT_CUSTOM_000P0E_PLUS0 = 48;
+    const NUMFORMAT_TEXT = 49;
 
-	const ALIGNH_GENERAL = 0;
-	const ALIGNH_LEFT = 1;
-	const ALIGNH_CENTER = 2;
-	const ALIGNH_RIGHT = 3;
-	const ALIGNH_FILL = 4;
-	const ALIGNH_JUSTIFY = 5;
-	const ALIGNH_MERGE = 6;
-	const ALIGNH_DISTRIBUTED = 7;
+    const ALIGNH_GENERAL = 0;
+    const ALIGNH_LEFT = 1;
+    const ALIGNH_CENTER = 2;
+    const ALIGNH_RIGHT = 3;
+    const ALIGNH_FILL = 4;
+    const ALIGNH_JUSTIFY = 5;
+    const ALIGNH_MERGE = 6;
+    const ALIGNH_DISTRIBUTED = 7;
 
-	const ALIGNV_TOP = 0;
-	const ALIGNV_CENTER = 1;
-	const ALIGNV_BOTTOM = 2;
-	const ALIGNV_JUSTIFY = 3;
-	const ALIGNV_DISTRIBUTED = 4;
+    const ALIGNV_TOP = 0;
+    const ALIGNV_CENTER = 1;
+    const ALIGNV_BOTTOM = 2;
+    const ALIGNV_JUSTIFY = 3;
+    const ALIGNV_DISTRIBUTED = 4;
 
-	const BORDERSTYLE_NONE = 0;
-	const BORDERSTYLE_THIN = 1;
-	const BORDERSTYLE_MEDIUM = 2;
-	const BORDERSTYLE_DASHED = 3;
-	const BORDERSTYLE_DOTTED = 4;
-	const BORDERSTYLE_THICK = 5;
-	const BORDERSTYLE_DOUBLE = 6;
-	const BORDERSTYLE_HAIR = 7;
-	const BORDERSTYLE_MEDIUMDASHED = 8;
-	const BORDERSTYLE_DASHDOT = 9;
-	const BORDERSTYLE_MEDIUMDASHDOT = 10;
-	const BORDERSTYLE_DASHDOTDOT = 11;
-	const BORDERSTYLE_MEDIUMDASHDOTDOT = 12;
-	const BORDERSTYLE_SLANTDASHDOT = 13;
+    const BORDERSTYLE_NONE = 0;
+    const BORDERSTYLE_THIN = 1;
+    const BORDERSTYLE_MEDIUM = 2;
+    const BORDERSTYLE_DASHED = 3;
+    const BORDERSTYLE_DOTTED = 4;
+    const BORDERSTYLE_THICK = 5;
+    const BORDERSTYLE_DOUBLE = 6;
+    const BORDERSTYLE_HAIR = 7;
+    const BORDERSTYLE_MEDIUMDASHED = 8;
+    const BORDERSTYLE_DASHDOT = 9;
+    const BORDERSTYLE_MEDIUMDASHDOT = 10;
+    const BORDERSTYLE_DASHDOTDOT = 11;
+    const BORDERSTYLE_MEDIUMDASHDOTDOT = 12;
+    const BORDERSTYLE_SLANTDASHDOT = 13;
 
-	const BORDERDIAGONAL_NONE = 0;
-	const BORDERDIAGONAL_DOWN = 1;
-	const BORDERDIAGONAL_UP = 2;
-	const BORDERDIAGONAL_BOTH = 3;
+    const BORDERDIAGONAL_NONE = 0;
+    const BORDERDIAGONAL_DOWN = 1;
+    const BORDERDIAGONAL_UP = 2;
+    const BORDERDIAGONAL_BOTH = 3;
 
-	const FILLPATTERN_NONE = 0;
-	const FILLPATTERN_SOLID = 1;
-	const FILLPATTERN_GRAY50 = 2;
-	const FILLPATTERN_GRAY75 = 3;
-	const FILLPATTERN_GRAY25 = 4;
-	const FILLPATTERN_HORSTRIPE = 5;
-	const FILLPATTERN_VERSTRIPE = 6;
-	const FILLPATTERN_REVDIAGSTRIPE = 7;
-	const FILLPATTERN_DIAGSTRIPE = 8;
-	const FILLPATTERN_DIAGCROSSHATCH = 9;
-	const FILLPATTERN_THICKDIAGCROSSHATCH = 10;
-	const FILLPATTERN_THINHORSTRIPE = 11;
-	const FILLPATTERN_THINVERSTRIPE = 12;
-	const FILLPATTERN_THINREVDIAGSTRIPE = 13;
-	const FILLPATTERN_THINDIAGSTRIPE = 14;
-	const FILLPATTERN_THINHORCROSSHATCH = 15;
-	const FILLPATTERN_THINDIAGCROSSHATCH = 16;
-	const FILLPATTERN_GRAY12P5 = 17;
-	const FILLPATTERN_GRAY6P25 = 18;
-	/**
-	* Create a format within an Excel workbook
-	*
-	* @see ExcelBook::addFormat()
-	* @param ExcelBook $book
-	* @return ExcelFormat
-	*/
-	public function __construct(ExcelBook $book)
-	{
-	} // __construct
+    const FILLPATTERN_NONE = 0;
+    const FILLPATTERN_SOLID = 1;
+    const FILLPATTERN_GRAY50 = 2;
+    const FILLPATTERN_GRAY75 = 3;
+    const FILLPATTERN_GRAY25 = 4;
+    const FILLPATTERN_HORSTRIPE = 5;
+    const FILLPATTERN_VERSTRIPE = 6;
+    const FILLPATTERN_REVDIAGSTRIPE = 7;
+    const FILLPATTERN_DIAGSTRIPE = 8;
+    const FILLPATTERN_DIAGCROSSHATCH = 9;
+    const FILLPATTERN_THICKDIAGCROSSHATCH = 10;
+    const FILLPATTERN_THINHORSTRIPE = 11;
+    const FILLPATTERN_THINVERSTRIPE = 12;
+    const FILLPATTERN_THINREVDIAGSTRIPE = 13;
+    const FILLPATTERN_THINDIAGSTRIPE = 14;
+    const FILLPATTERN_THINHORCROSSHATCH = 15;
+    const FILLPATTERN_THINDIAGCROSSHATCH = 16;
+    const FILLPATTERN_GRAY12P5 = 17;
+    const FILLPATTERN_GRAY6P25 = 18;
 
-	/**
-	* Get, or set the color of the bottom border of a cell
-	*
-	* @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
-	* @return int
-	*/
-	public function borderBottomColor($color = null)
-	{
-	} // borderBottomColor
+    /**
+     * Create a format within an Excel workbook
+     *
+     * @param ExcelBook $book
+     * @return ExcelFormat
+     * @see ExcelBook::addFormat()
+     */
+    public function __construct(ExcelBook $book)
+    {
+    } // __construct
 
-	/**
-	* Get, or set the border style for the bottom of a cell
-	*
-	* @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
-	* @return int
-	*/
-	public function borderBottomStyle($style = null)
-	{
-	} // borderBottomStyle
+    /**
+     * Get, or set the color of the bottom border of a cell
+     *
+     * @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
+     * @return int
+     */
+    public function borderBottomColor($color = null)
+    {
+    } // borderBottomColor
 
-	/**
-	* Set the border color on all sides of a cell
-	*
-	* @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
-	* @return int The color, or true if no value supplied for $color
-	*/
-	public function borderColor($color = null)
-	{
-	} // borderColor
+    /**
+     * Get, or set the border style for the bottom of a cell
+     *
+     * @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
+     * @return int
+     */
+    public function borderBottomStyle($style = null)
+    {
+    } // borderBottomStyle
 
-	/**
-	* Get, or set the color of the diagonal of a cell
-	*
-	* @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
-	* @return int
-	*/
-	public function borderDiagonalColor($color = null)
-	{
-	} // borderDiagonalColor
+    /**
+     * Set the border color on all sides of a cell
+     *
+     * @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
+     * @return int The color, or true if no value supplied for $color
+     */
+    public function borderColor($color = null)
+    {
+    } // borderColor
 
-	/**
-	* Get, or set the border for the diagonal of a cell
-	*
-	* @param int $style (optional, default=null) One of ExcelFormat::BORDERDIAGONAL_* constants
-	* @return int
-	*/
-	public function borderDiagonalStyle($style = null)
-	{
-	} // borderDiagonalStyle
+    /**
+     * Get, or set the color of the diagonal of a cell
+     *
+     * @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
+     * @return int
+     */
+    public function borderDiagonalColor($color = null)
+    {
+    } // borderDiagonalColor
 
-	/**
-	* Get, or set the color of the left side border of a cell
-	*
-	* @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
-	* @return int
-	*/
-	public function borderLeftColor($color = null)
-	{
-	} // borderLeftColor
+    /**
+     * Get, or set the border for the diagonal of a cell
+     *
+     * @param int $style (optional, default=null) One of ExcelFormat::BORDERDIAGONAL_* constants
+     * @return int
+     */
+    public function borderDiagonalStyle($style = null)
+    {
+    } // borderDiagonalStyle
 
-	/**
-	* Get, or set the border style for the left side of a cell
-	*
-	* @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
-	* @return int
-	*/
-	public function borderLeftStyle($style = null)
-	{
-	} // borderLeftStyle
+    /**
+     * Get, or set the color of the left side border of a cell
+     *
+     * @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
+     * @return int
+     */
+    public function borderLeftColor($color = null)
+    {
+    } // borderLeftColor
 
-	/**
-	* Get, or set the color of the right side border of a cell
-	*
-	* @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
-	* @return int
-	*/
-	public function borderRightColor($color = null)
-	{
-	} // borderRightColor
+    /**
+     * Get, or set the border style for the left side of a cell
+     *
+     * @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
+     * @return int
+     */
+    public function borderLeftStyle($style = null)
+    {
+    } // borderLeftStyle
 
-	/**
-	* Get, or set the border style for the right side of a cell
-	*
-	* @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
-	* @return int
-	*/
-	public function borderRightStyle($style = null)
-	{
-	} // borderRightStyle
+    /**
+     * Get, or set the color of the right side border of a cell
+     *
+     * @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
+     * @return int
+     */
+    public function borderRightColor($color = null)
+    {
+    } // borderRightColor
 
-	/**
-	* Set the cell border style on all sides of a cell
-	*
-	* @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
-	* @return int The border style, or true if no value supplied for $style
-	*/
-	public function borderStyle($style = null)
-	{
-	} // borderStyle
+    /**
+     * Get, or set the border style for the right side of a cell
+     *
+     * @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
+     * @return int
+     */
+    public function borderRightStyle($style = null)
+    {
+    } // borderRightStyle
 
-	/**
-	* Get, or set the color of the top border of a cell
-	*
-	* @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
-	* @return int
-	*/
-	public function borderTopColor($color = null)
-	{
-	} // borderTopColor
+    /**
+     * Set the cell border style on all sides of a cell
+     *
+     * @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
+     * @return int The border style, or true if no value supplied for $style
+     */
+    public function borderStyle($style = null)
+    {
+    } // borderStyle
 
-	/**
-	* Get, or set the border style for the top of a cell
-	*
-	* @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
-	* @return int
-	*/
-	public function borderTopStyle($style = null)
-	{
-	} // borderTopStyle
+    /**
+     * Get, or set the color of the top border of a cell
+     *
+     * @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
+     * @return int
+     */
+    public function borderTopColor($color = null)
+    {
+    } // borderTopColor
 
-	/**
-	* Get, or set the cell fill pattern
-	*
-	* @param int $pattern (optional, default=null) One of ExcelFormat::FILLPATTERN_* constants
-	* @return int
-	*/
-	public function fillPattern($pattern = null)
-	{
-	} // fillPattern
+    /**
+     * Get, or set the border style for the top of a cell
+     *
+     * @param int $style (optional, default=null) One of ExcelFormat::BORDERSTYLE_* constants
+     * @return int
+     */
+    public function borderTopStyle($style = null)
+    {
+    } // borderTopStyle
 
-	/**
-	* Get the font for this format
-	*
-	* @see ExcelFormat::setFont()
-	* @return ExcelFont
-	*/
-	public function getFont()
-	{
-	} // getFont
+    /**
+     * Get, or set the cell fill pattern
+     *
+     * @param int $pattern (optional, default=null) One of ExcelFormat::FILLPATTERN_* constants
+     * @return int
+     */
+    public function fillPattern($pattern = null)
+    {
+    } // fillPattern
 
-	/**
-	* Get, or set whether the cell is hidden
-	*
-	* @param bool $hidden (optional, default=null)
-	* @return bool
-	*/
-	public function hidden($hidden = null)
-	{
-	} // hidden
+    /**
+     * Get the font for this format
+     *
+     * @return ExcelFont
+     * @see ExcelFormat::setFont()
+     */
+    public function getFont()
+    {
+    } // getFont
 
-	/**
-	* Get, or set the cell horizontal alignment
-	*
-	* @see ExcelFormat::verticalAlign()
-	* @param int $halign_mode (optional, default=null) One of ExcelFormat::ALIGNH_* constants
-	* @return int
-	*/
-	public function horizontalAlign($halign_mode = null)
-	{
-	} // horizontalAlign
+    /**
+     * Get, or set whether the cell is hidden
+     *
+     * @param bool $hidden (optional, default=null)
+     * @return bool
+     */
+    public function hidden($hidden = null)
+    {
+    } // hidden
 
-	/**
-	* Get, or set the cell text indentation level
-	*
-	* @param int $indent (optional, default=null) A number from 0-15
-	* @return int
-	*/
-	public function indent($indent = null)
-	{
-	} // indent
+    /**
+     * Get, or set the cell horizontal alignment
+     *
+     * @param int $halign_mode (optional, default=null) One of ExcelFormat::ALIGNH_* constants
+     * @return int
+     * @see ExcelFormat::verticalAlign()
+     */
+    public function horizontalAlign($halign_mode = null)
+    {
+    } // horizontalAlign
 
-	/**
-	* Get, or set whether a cell is locked
-	*
-	* @param bool $locked (optional, default=null)
-	* @return bool
-	*/
-	public function locked($locked)
-	{
-	} // locked
+    /**
+     * Get, or set the cell text indentation level
+     *
+     * @param int $indent (optional, default=null) A number from 0-15
+     * @return int
+     */
+    public function indent($indent = null)
+    {
+    } // indent
 
-	/**
-	* Get, or set the cell number format
-	*
-	* @param int $number_format Number format identifier.  One of ExcelFormat::NUMFORMAT_* constants
-	* @return int
-	*/
-	public function numberFormat($number_format = null)
-	{
-	} // numberFormat
+    /**
+     * Get, or set whether a cell is locked
+     *
+     * @param bool $locked (optional, default=null)
+     * @return bool
+     */
+    public function locked($locked)
+    {
+    } // locked
 
-	/**
-	* Get, or set the pattern background color
-	*
-	* @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
-	* @return int
-	*/
-	public function patternBackgroundColor($color = null)
-	{
-	} // patternBackgroundColor
+    /**
+     * Get, or set the cell number format
+     *
+     * @param int $number_format Number format identifier.  One of ExcelFormat::NUMFORMAT_* constants
+     * @return int
+     */
+    public function numberFormat($number_format = null)
+    {
+    } // numberFormat
 
-	/**
-	* Get, or set the pattern foreground color
-	*
-	* @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
-	* @return int
-	*/
-	public function patternForegroundColor($color = null)
-	{
-	} // patternForegroundColor
+    /**
+     * Get, or set the pattern background color
+     *
+     * @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
+     * @return int
+     */
+    public function patternBackgroundColor($color = null)
+    {
+    } // patternBackgroundColor
 
-	/**
-	* Get, or set the cell data rotation
-	*
-	* @param int $angle (optional, default=null) 0 to 90 (rotate left 0-90 degrees), 91 to 180 (rotate right 1-90 degrees), or 255 for vertical text
-	* @return int The angle of rotation, or false if setting an invalid value
-	*/
-	public function rotate($angle = null)
-	{
-	} // rotate
+    /**
+     * Get, or set the pattern foreground color
+     *
+     * @param int $color (optional, default=null) One of ExcelFormat::COLOR_* constants
+     * @return int
+     */
+    public function patternForegroundColor($color = null)
+    {
+    } // patternForegroundColor
 
-	/**
-	* Set the font for this format
-	*
-	* @see ExcelFormat::getFont()
-	* @param ExcelFont $font
-	* @return bool
-	*/
-	public function setFont($font)
-	{
-	} // setFont
+    /**
+     * Get, or set the cell data rotation
+     *
+     * @param int $angle (optional, default=null) 0 to 90 (rotate left 0-90 degrees), 91 to 180 (rotate right 1-90 degrees), or 255 for vertical text
+     * @return int The angle of rotation, or false if setting an invalid value
+     */
+    public function rotate($angle = null)
+    {
+    } // rotate
 
-	/**
-	* Get, or set whether the cell is shrink-to-fit
-	*
-	* @param bool $shrink (optional, default=null)
-	* @return bool
-	*/
-	public function shrinkToFit($shrink = null)
-	{
-	} // shrinkToFit
+    /**
+     * Set the font for this format
+     *
+     * @param ExcelFont $font
+     * @return bool
+     * @see ExcelFormat::getFont()
+     */
+    public function setFont($font)
+    {
+    } // setFont
 
-	/**
-	* Get, or set the cell vertical alignment
-	*
-	* @see ExcelFormat::horizontalAlign()
-	* @param int $valign_mode (optional, default=null) One of ExcelFormat::ALIGNV_* constants
-	* @return int
-	*/
-	public function verticalAlign($valign_mode = null)
-	{
-	} // verticalAlign
+    /**
+     * Get, or set whether the cell is shrink-to-fit
+     *
+     * @param bool $shrink (optional, default=null)
+     * @return bool
+     */
+    public function shrinkToFit($shrink = null)
+    {
+    } // shrinkToFit
 
-	/**
-	* Get, or set the cell text wrapping
-	*
-	* @param bool $wrap (optional, default=null)
-	* @return bool
-	*/
-	public function wrap($wrap = null)
-	{
-	} // wrap
+    /**
+     * Get, or set the cell vertical alignment
+     *
+     * @param int $valign_mode (optional, default=null) One of ExcelFormat::ALIGNV_* constants
+     * @return int
+     * @see ExcelFormat::horizontalAlign()
+     */
+    public function verticalAlign($valign_mode = null)
+    {
+    } // verticalAlign
+
+    /**
+     * Get, or set the cell text wrapping
+     *
+     * @param bool $wrap (optional, default=null)
+     * @return bool
+     */
+    public function wrap($wrap = null)
+    {
+    } // wrap
 
 } // end ExcelFormat

--- a/docs/ExcelSheet.php
+++ b/docs/ExcelSheet.php
@@ -1021,7 +1021,7 @@ class ExcelSheet
 	} // readCol
 
 	/**
-	* Read comment from a cell
+	* Read comment from a cell (only for xls files)
 	*
 	* @param int $row 0-based row number
 	* @param int $column 0-based column number
@@ -1659,7 +1659,7 @@ class ExcelSheet
 	} // writeCol
 
 	/**
-	* Write comment to a cell
+	* Write comment to a cell (only for xls files)
 	*
 	* @param int $row 0-based row number
 	* @param int $column 0-based column number

--- a/docs/ExcelSheet.php
+++ b/docs/ExcelSheet.php
@@ -1699,6 +1699,21 @@ class ExcelSheet
 	{
 	} // writeRow
 
+    /**
+     * Write formula with value into a cell
+     *
+     * @since libXL 3.7.0.0
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @param mixed $expr
+     * @param mixed $value
+     * @param ExcelFormat $format (optional, default=null)
+     * @return bool
+     */
+    public function writeFormula($row, $column, $expr, $value, $format = null)
+    {
+    } // writeFormula
+
 	/**
 	* Returns the zoom level of the current view as a percentage
 	*

--- a/docs/ExcelSheet.php
+++ b/docs/ExcelSheet.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
   +---------------------------------------------------------------------------+
   | ExcelSheet                                                                |
@@ -12,1724 +13,1725 @@
   | Rob Gagnon <rgagnon24@gmail.com>                                          |
   +---------------------------------------------------------------------------+
 */
+
 class ExcelSheet
 {
-	const PAPER_DEFAULT = 0;
-	const PAPER_LETTER = 1;
-	const PAPER_LETTERSMALL = 2;
-	const PAPER_TABLOID = 3;
-	const PAPER_LEDGER = 4;
-	const PAPER_LEGAL = 5;
-	const PAPER_STATEMENT = 6;
-	const PAPER_EXECUTIVE = 7;
-	const PAPER_A3 = 8;
-	const PAPER_A4 = 9;
-	const PAPER_A4SMALL = 10;
-	const PAPER_A5 = 11;
-	const PAPER_B4 = 12;
-	const PAPER_B5 = 13;
-	const PAPER_FOLIO = 14;
-	const PAPER_QUATRO = 15;
-	const PAPER_10x14 = 16;
-	const PAPER_10x17 = 17;
-	const PAPER_NOTE = 18;
-	const PAPER_ENVELOPE_9 = 19;
-	const PAPER_ENVELOPE_10 = 20;
-	const PAPER_ENVELOPE_11 = 21;
-	const PAPER_ENVELOPE_12 = 22;
-	const PAPER_ENVELOPE_14 = 23;
-	const PAPER_C_SIZE = 24;
-	const PAPER_D_SIZE = 25;
-	const PAPER_E_SIZE = 26;
-	const PAPER_ENVELOPE_DL = 27;
-	const PAPER_ENVELOPE_C5 = 28;
-	const PAPER_ENVELOPE_C3 = 29;
-	const PAPER_ENVELOPE_C4 = 30;
-	const PAPER_ENVELOPE_C6 = 31;
-	const PAPER_ENVELOPE_C65 = 32;
-	const PAPER_ENVELOPE_B4 = 33;
-	const PAPER_ENVELOPE_B5 = 34;
-	const PAPER_ENVELOPE_B6 = 35;
-	const PAPER_ENVELOPE = 36;
-	const PAPER_ENVELOPE_MONARCH = 37;
-	const PAPER_US_ENVELOPE = 38;
-	const PAPER_FANFOLD = 39;
-	const PAPER_GERMAN_STD_FANFOLD = 40;
-	const PAPER_GERMAN_LEGAL_FANFOLD = 41;
-
-	const CELLTYPE_EMPTY = 0;
-	const CELLTYPE_NUMBER = 1;
-	const CELLTYPE_STRING = 2;
-	const CELLTYPE_BOOLEAN = 3;
-	const CELLTYPE_BLANK = 4;
-	const CELLTYPE_ERROR = 5;
-
-	const ERRORTYPE_NULL = 0;
-	const ERRORTYPE_DIV_0 = 7;
-	const ERRORTYPE_VALUE = 15;
-	const ERRORTYPE_REF = 23;
-	const ERRORTYPE_NAME = 29;
-	const ERRORTYPE_NUM = 36;
-	const ERRORTYPE_NA = 42;
-	const ERRORTYPE_NOERROR = 255;
-
-	const LEFT_TO_RIGHT = 0;
-	const RIGHT_TO_LEFT = 1;
-
-	const IERR_EVAL_ERROR = 1;
-	const IERR_EMPTY_CELLREF = 2;
-	const IERR_NUMBER_STORED_AS_TEXT = 4;
-	const IERR_INCONSIST_RANGE = 8;
-	const IERR_INCONSIST_FMLA = 16;
-	const IERR_TWODIG_TEXTYEAR = 32;
-	const IERR_UNLOCK_FMLA = 64;
-	const IERR_DATA_VALIDATION = 128;
-
-	const PROT_DEFAULT = -1;
-	const PROT_ALL = 0;
-	const PROT_OBJECTS = 1;
-	const PROT_SCENARIOS = 2;
-	const PROT_FORMAT_CELLS = 4;
-	const PROT_FORMAT_COLUMNS = 8;
-	const PROT_FORMAT_ROWS = 16;
-	const PROT_INSERT_COLUMNS = 32;
-	const PROT_INSERT_ROWS = 64;
-	const PROT_INSERT_HYPERLINKS = 128;
-	const PROT_DELETE_COLUMNS = 256;
-	const PROT_DELETE_ROWS = 512;
-	const PROT_SEL_LOCKED_CELLS = 1024;
-	const PROT_SORT = 2048;
-	const PROT_AUTOFILTER = 4096;
-	const PROT_PIVOTTABLES = 8192;
-	const PROT_SEL_UNLOCKED_CELLS = 16384;
-
-	const SHEETSTATE_VISIBLE = 0;
-	const SHEETSTATE_HIDDEN = 1;
-	const SHEETSTATE_VERYHIDDEN = 2;
-
-	const VALIDATION_TYPE_NONE = 0;
-	const VALIDATION_TYPE_WHOLE = 1;
-	const VALIDATION_TYPE_DECIMAL = 2;
-	const VALIDATION_TYPE_LIST = 3;
-	const VALIDATION_TYPE_DATE = 4;
-	const VALIDATION_TYPE_TIME = 5;
-	const VALIDATION_TYPE_TEXTLENGTH = 6;
-	const VALIDATION_TYPE_CUSTOM = 7;
-
-	const VALIDATION_OP_BETWEEN = 0;
-	const VALIDATION_OP_NOTBETWEEN = 1;
-	const VALIDATION_OP_EQUAL = 2;
-	const VALIDATION_OP_NOTEQUAL = 3;
-	const VALIDATION_OP_LESSTHAN = 4;
-	const VALIDATION_OP_LESSTHANOREQUAL = 5;
-	const VALIDATION_OP_GREATERTHAN = 6;
-	const VALIDATION_OP_GREATERTHANOREQUAL = 7;
-
-	const VALIDATION_ERRSTYLE_STOP = 0; // stop icon in the error alert
-	const VALIDATION_ERRSTYLE_WARNING = 1; // warning icon in the error alert
-	const VALIDATION_ERRSTYLE_INFORMATION = 2; // information icon in the error alert
-
-	/**
-	* Create an ExcelSheet in given Workbook
-	*
-	* @param ExcelBook $book
-	* @param string $name The name for the new worksheet
-	* @return ExcelSheet The worksheet created
-	*/
-	public function __construct(ExcelBook $book, $name)
-	{
-	} // __construct
-
-	/**
-	* Adds a data validation for the specified range (only for xlsx files).
-	*
-	* @since libXL 3.8.0.0
-	* @param int $type - one of the ExcelSheet::VALIDATION_TYPE_* constants
-	* @param int $op - one of the ExcelSheet::VALIDATION_OP_* constants
-	* @param int $row_first 0-based
-	* @param int $row_last 0-based
-	* @param int $col_first 0-based
-	* @param int $col_last 0-based
-	* @param string $val_1 the first value for relational operator
-	* @param string $val_2 the second value for VALIDATION_OP_BETWEEN or VALIDATION_OP_NOTBETWEEN operator
-	* @param bool $allow_blank (optional, default = true) a boolean value indicating whether the data validation treats empty or blank entries as valid, 'true' means empty entries are OK and do not violate the validation constraints
-	* @param bool $hide_dropdown (optional, default = false) a boolean value indicating whether to display the dropdown combo box for a list type data validation (ExcelSheet::VALIDATION_TYPE_LIST)
-	* @param bool $show_inputmessage (optional, default = true) a boolean value indicating whether to display the input prompt message
-	* @param bool $show_errormessage (optional, default = true) a boolean value indicating whether to display the error alert message when an invalid value has been entered, according to the criteria specified
-	* @param string $prompt_title (optional, default = '') title bar text of input prompt
-	* @param string $prompt (optional, default = '') message text of input prompt
-	* @param string $error_title (optional, default = '') title bar text of error alert
-	* @param string $error (optional, default = '') message text of error alert
-	* @param int $error_style - (optional, default = \ExcelSheet::VALIDATION_ERRSTYLE_WARNING) one of the ExcelSheet::VALIDATION_ERRSTYLE_* constants
-	*/
-	public function addDataValidation($type, $op, $row_first, $row_last, $col_first, $col_last, $val_1, $val_2 = null, $allow_blank = true, $hide_dropdown = false, $show_inputmessage = true, $show_errormessage = true, $prompt_title = '', $prompt = '', $error_title = '', $error = '', $error_style = \ExcelSheet::VALIDATION_ERRSTYLE_WARNING)
-	{
-	} // addDataValidation
-
-	/**
-	* Adds a data validation for the specified range with double or date values for the relational
-	* operator (only for xlsx files).
-	*
-	* @since libXL 3.8.0.0
-	* @param int $type - one of the ExcelSheet::VALIDATION_TYPE_* constants
-	* @param int $op - one of the ExcelSheet::VALIDATION_OP_* constants
-	* @param int $row_first 0-based
-	* @param int $row_last 0-based
-	* @param int $col_first 0-based
-	* @param int $col_last 0-based
-	* @param float $val_1 the first value for relational operator
-	* @param float $val_2 the second value for VALIDATION_OP_BETWEEN or VALIDATION_OP_NOTBETWEEN operator
-	* @param bool $allow_blank (optional, default = true) a boolean value indicating whether the data validation treats empty or blank entries as valid, 'true' means empty entries are OK and do not violate the validation constraints
-	* @param bool $hide_dropdown (optional, default = false) a boolean value indicating whether to display the dropdown combo box for a list type data validation (ExcelSheet::VALIDATION_TYPE_LIST)
-	* @param bool $show_inputmessage (optional, default = true) a boolean value indicating whether to display the input prompt message
-	* @param bool $show_errormessage (optional, default = true) a boolean value indicating whether to display the error alert message when an invalid value has been entered, according to the criteria specified
-	* @param string $prompt_title (optional, default = '') title bar text of input prompt
-	* @param string $prompt (optional, default = '') message text of input prompt
-	* @param string $error_title (optional, default = '') title bar text of error alert
-	* @param string $error (optional, default = '') message text of error alert
-	* @param int $error_style - (optional, default = \ExcelSheet::VALIDATION_ERRSTYLE_WARNING) one of the ExcelSheet::VALIDATION_ERRSTYLE_* constants
-	*/
-	public function addDataValidationDouble($type, $op, $row_first, $row_last, $col_first, $col_last, $val_1, $val_2 = null, $allow_blank = true, $hide_dropdown = false, $show_inputmessage = true, $show_errormessage = true, $prompt_title = '', $prompt = '', $error_title = '', $error = '', $error_style = \ExcelSheet::VALIDATION_ERRSTYLE_WARNING)
-	{
-	} // addDataValidationDouble
-
-	/**
-	* Adds the new hyperlink.
-	*
-	* @param string $hyperlink
-	* @param int $row_first 0-based
-	* @param int $row_last 0-based
-	* @param int $col_first 0-based
-	* @param int $col_last 0-based
-	* @return void
-	*/
-	public function addHyperlink($hyperlink, $row_first, $row_last, $col_first, $col_last)
-	{
-	} // addHyperlink
-
-	/**
-	* Adds the ignored error for specified range. It allows to hide green triangles on left sides of cells.
-	*
-	* @param int $error - one of the ExcelSheet::IERR_* constants
-	* @param int $row_first 0-based (optional, default = 0)
-	* @param int $col_first 0-based (optional, default = 0)
-	* @param int $row_last 0-based (optional, default = 0)
-	* @param int $col_last 0-based (optional, default = 0)
-	* @return bool
-	*/
-	public function addIgnoredError($error, $row_first=0, $col_first=0, $row_last=0, $col_last=0)
-	{
-	} // addIgnoredError
-
-	/**
-	* Insert a picture into a cell with given dimensions
-	*
-	* @see ExcelBook::addPictureFromString()
-	* @see ExcelBook::addPictureFromFile()
-	* @see ExcelSheet::addPictureScaled()
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @param int $picture_id Value returned by ExcelBook::addPictureFrom*() methods
-	* @param int $width
-	* @param int $height
-	* @param int $x_offset (optional, default=0)
-	* @param int $y_offset (optional, default=0)
-	* @return void
-	*/
-	public function addPictureDim($row, $column, $picture_id, $width, $height, $x_offset = 0, $y_offset = 0)
-	{
-	} // addPictureDim
-
-	/**
-	* Insert a picture into a cell with a set scale
-	*
-	* @see ExcelBook::addPictureFromString()
-	* @see ExcelBook::addPictureFromFile()
-	* @see ExcelSheet::addPictureDim()
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @param int $picture_id Value returned by ExcelBook::addPictureFrom*() methods
-	* @param float $scale
-	* @param int $x_offset (optional, default = 0)
-	* @param int $y_offset (optional, default = 0)
-	* @return void
-	*/
-	public function addPictureScaled($row, $column, $picture_id, $scale, $x_offset = 0, $y_offset = 0)
-	{
-	} // addPictureScaled
-
-	/**
-	* Converts a cell reference to row and column.
-	*
-	* @param string $cell_reference
-	* @return array with keys "row"(int), "column"(int), "col_relative"(bool), "row_relative"(bool)
-	*/
-	public function addrToRowCol($cell_reference)
-	{
-	} // addrToRowCol
-
-	/**
-	* Returns the AutoFilter. Creates it if it doesn't exist.
-	*
-	* @return ExcelAutoFilter
-	*/
-	public function autoFilter()
-	{
-	} // autoFilter
-
-	/**
-	* Applies the AutoFilter to the sheet.
-	*
-	* @return bool
-	*/
-	public function applyFilter()
-	{
-	} // applyFilter
-
-	/**
-	* Removes the AutoFilter from the sheet.
-	*
-	* @return bool
-	*/
-	public function removeFilter()
-	{
-	} // removeFilter
-
-	/**
-	* Get the cell format
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @return ExcelFormat
-	*/
-	public function cellFormat($row, $column)
-	{
-	} // cellFormat
-
-	/**
-	* Get the cell type
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @return int One of ExcelSheet::CELLTYPE_* constants
-	*/
-	public function cellType($row, $column)
-	{
-	} // cellType
-
-	/**
-	* Clear cells in the specified area
-	*
-	* @param int $row_start 0-based row number
-	* @param int $row_end 0-based row number
-	* @param int $column_start 0-based column number
-	* @param int $column_end 0-based column number
-	* @return void
-	*/
-	public function clear($row_start, $row_end, $column_start, $column_end)
-	{
-	} // clear
-
-	/**
-	* Sets the print area.
-	*
-	* @param int $row_start 0-based row number
-	* @param int $row_end 0-based row number
-	* @param int $column_start 0-based column number
-	* @param int $column_end 0-based column number
-	* @return bool
-	*/
-	public function setPrintArea($row_start, $row_end, $column_start, $column_end)
-	{
-	} // setPrintArea
-
-	/**
-	* Gets the print area. Returns false if print area isn't found.
-	*
-	* @return bool|array with keys "row_start"(int), "row_end"(int), "col_start"(int) and "col_end"(int)
-	*/
-	public function printArea()
-	{
-	} // printArea
-
-	/**
-	* Clears the print area
-	*
-	* @return bool
-	*/
-	public function clearPrintArea()
-	{
-	} // clearPrintArea
-
-	/**
-	* Clears repeated rows and columns on each page
-	*
-	* @see ExcelSheet::setPrintRepeatRows()
-	* @see ExcelSheet::setPrintRepeatCols()
-	* @return bool
-	*/
-	public function clearPrintRepeats()
-	{
-	} // clearPrintRepeats
-
-	/**
-	* Returns whether column is hidden.
-	*
-	* @param int $column 0-based column number
-	* @return bool
-	*/
-	public function colHidden($column)
-	{
-	} // colHidden
-
-	/**
-	* Returns the cell width
-	*
-	* @see ExcelSheet::rowHeight()
-	* @see ExcelSheet::colWidthPx()
-	* @see ExcelSheet::setColWidth()
-	* @see ExcelSheet::setRowHeight()
-	* @param int $column 0-based column number
-	* @return float
-	*/
-	public function colWidth($column)
-	{
-	} // colWidth
-
-	/**
-	* Returns the cell width
-	*
-	* @see ExcelSheet::rowHeight()
-	* @see ExcelSheet::colWidth()
-	* @see ExcelSheet::setColWidth()
-	* @see ExcelSheet::setRowHeight()
-	* @param int $column 0-based column number
-	* @return float
-	*/
-	public function colWidthPx($column)
-	{
-	} // colWidthPx
-
-	/**
-	* Copy a cell from one location to another
-	*
-	* @param int $row_from 0-based row number
-	* @param int $column_from 0-based column number
-	* @param int $row_to 0-based row number
-	* @param int $column_to 0-based column number
-	* @return void
-	*/
-	public function copy($row_from, $column_from, $row_to, $column_to)
-	{
-	} // copy
-
-	/**
-	* Removes hyperlink by index.
-	*
-	* @param int $index
-	* @return bool
-	*/
-	public function delHyperlink($index)
-	{
-	} // delHyperlink
-
-	/**
-	* Delete a named range
-	*
-	* @see ExcelSheet::setNamedRange()
-	* @param string $name
-	* @param int $scope_id
-	* @return bool
-	*/
-	public function delNamedRange($name, $scope_id = null)
-	{
-	} // delNamedRange
-
-	/**
-	* Delete cell merge
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @return bool
-	*/
-	public function deleteMerge($row, $column)
-	{
-	} // deleteMerge
-
-	/**
-	* Removes merged cells by index.
-	*
-	* @param int $index
-	* @return bool
-	*/
-	public function delMergeByIndex($index)
-	{
-	} // delMergeByIndex
-
-	/**
-	* Returns whether the gridlines are displayed
-	*
-	* @see ExcelSheet::setDisplayGridlines()
-	* @return bool
-	*/
-	public function displayGridlines()
-	{
-	} // displayGridlines
-
-	/**
-	* Returns the 0-based first column in a sheet that contains a used cell
-	*
-	* @see ExcelSheet::firstRow()
-	* @see ExcelSheet::lastRow()
-	* @see ExcelSheet::lastCol()
-	* @return int
-	*/
-	public function firstCol()
-	{
-	} // firstCol
-
-	/**
-	* Returns the 0-based first row in a sheet that contains a used cell
-	*
-	* @see ExcelSheet::lastRow()
-	* @see ExcelSheet::firstCol()
-	* @see ExcelSheet::lastCol()
-	* @return int
-	*/
-	public function firstRow()
-	{
-	} // firstRow
-
-	/**
-	* Returns the footer text of the sheet when printed
-	*
-	* @see ExcelSheet::header()
-	* @see ExcelSheet::setFooter()
-	* @see ExcelSheet::setHeader()
-	* @return string
-	*/
-	public function footer()
-	{
-	} // footer
-
-	/**
-	* Returns the footer margin (in inches)
-	*
-	* @see ExcelSheet::setFooter()
-	* @see ExcelSheet::headerMargin()
-	* @return float
-	*/
-	public function footerMargin()
-	{
-	} // footerMargin
-
-	/**
-	* Returns whether grouping rows summary is below, or above
-	*
-	* @see ExcelSheet::setGroupSummaryBelow()
-	* @see ExcelSheet::getGroupSummaryRight()
-	* @see ExcelSheet::setGroupSummaryRight()
-	* @return bool true=below, false=above
-	*/
-	public function getGroupSummaryBelow()
-	{
-	} // getGroupSummaryBelow
-
-	/**
-	* Returns whether grouping columns summary is right, or left
-	*
-	* @see ExcelSheet::getGroupSummaryBelow()
-	* @see ExcelSheet::setGroupSummaryBelow()
-	* @see ExcelSheet::setGroupSummaryRight()
-	* @return bool true=right, false=left
-	*/
-	public function getGroupSummaryRight()
-	{
-	} // getGroupSummaryRight
-
-	/**
-	* Returns column with horizontal page break at position index.
-	*
-	* @param int $index
-	* @return int
-	*/
-	public function getHorPageBreak($index)
-	{
-	} // getHorPageBreak
-
-	/**
-	* Returns a number of horizontal page breaks in the sheet.
-	*
-	* @return int
-	*/
-	public function getHorPageBreakSize()
-	{
-	} // getHorPageBreakSize
-
-	/**
-	* Gets the named range coordinates by index.
-	*
-	* @param int $index
-	* @param int $scope_id (optional, default = null) index of sheet or -1 for Workbook
-	* @return array with keys "row_first"(int), "row_last"(int), "col_first"(int), "col_last"(int), "hidden"(bool), "scope"(int)
-	*/
-	public function getIndexRange($index, $scope_id = null)
-	{
-	} // getIndexRange
-
-	/**
-	* Get cell merge range
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @return array Four integers as keys "row_first", "row_last", "col_first", and "col_last"
-	*/
-	public function getMerge($row, $column)
-	{
-	} // getMerge
-
-	/**
-	* Gets the named range coordinates by name, returns false if range is not found.
-	*
-	* @param string $name
-	* @param int $scope_id (optional, default=null)
-	* @return array with keys "row_first"(int), "row_last"(int), "col_first"(int), "col_last"(int), "hidden"(bool)
-	*/
-	public function getNamedRange($name, $scope_id = null)
-	{
-	} // getNamedRange
-
-	/**
-	* Returns a number of pictures in this worksheet.
-	*
-	* @return int
-	*/
-	public function getNumPictures()
-	{
-	} // getNumPictures
-
-	/**
-	* Returns a information about a workbook picture at position index in worksheet.
-	*
-	* @param int $index
-	* @return array with keys "picture_index"(int), "row_top"(int), "col_left"(int), "row_bottom"(int), "col_right"(int), "width"(int), "height"(int), "offset_x"(int), "offset_y"(int)
-	*/
-	public function getPictureInfo($index)
-	{
-	} // getPictureInfo
-
-	/**
-	* Returns whether fit to page option is enabled, and if so to what width & height
-	*
-	* @return array with keys "width"(int), "height"(int)
-	*/
-	public function getPrintFit()
-	{
-	} // getPrintFit
-
-	/**
-	* Returns whether the text is displayed in right-to-left mode: 1 - yes, 0 - no.
-	*
-	* @return int
-	*/
-	public function getRightToLeft()
-	{
-	} // getRightToLeft
-
-	/**
-	* Extracts the first visible row and the leftmost visible column of the sheet.
-	*
-	* @return array with keys "row"(int), "column"(int)
-	*/
-	public function getTopLeftView()
-	{
-	} // getTopLeftView
-
-	/**
-	* Returns column with vertical page break at position index.
-	*
-	* @param int $index
-	* @return int
-	*/
-	public function getVerPageBreak($index)
-	{
-	} // getVerPageBreak
-
-	/**
-	* Returns a number of vertical page breaks in the sheet.
-	*
-	* @return int
-	*/
-	public function getVerPageBreakSize()
-	{
-	} // getVerPageBreakSize
-
-	/**
-	* Group columns from $column_start to $column_end
-	*
-	* @param int $column_start 0-based column number
-	* @param int $column_end 0-based column number
-	* @param bool $collapse (optional, default = false)
-	* @return bool
-	*/
-	public function groupCols($column_start, $column_end, $collapse = false)
-	{
-	} // groupCols
-
-	/**
-	* Group rows from $row_start to $row_end
-	*
-	* @param int $row_start 0-based row number
-	* @param int $row_end 0-based row number
-	* @param bool $collapse (optional, default = false)
-	* @return bool
-	*/
-	public function groupRows($row_start, $row_end, $collapse = false)
-	{
-	} // groupRows
-
-	/**
-	* Returns whether the sheet is centered horizontally when printed
-	*
-	* @see ExcelSheet::vcenter()
-	* @see ExcelSheet::setHCenter()
-	* @see ExcelSheet::setVCenter()
-	* @return bool
-	*/
-	public function hcenter()
-	{
-	} // hcenter
-
-	/**
-	* Returns the header text of the sheet when printed
-	*
-	* @see ExcelSheet::setHeader()
-	* @see ExcelSheet::footer()
-	* @see ExcelSheet::setFooter()
-	* @return string
-	*/
-	public function header()
-	{
-	} // header
-
-	/**
-	* Hides/unhides the sheet
-	*
-	* @deprecated
-	* @param bool $hide
-	* @return bool
-	*/
-	public function hidden($hide)
-	{
-	} // hidden
-
-	/**
-	* Gets the hyperlink and its coordinates by index.
-	*
-	* @param int $index
-	* @return array
-	*/
-	public function hyperlink($index)
-	{
-	} // hyperlink
-
-	/**
-	* Returns the number of hyperlinks in the sheet.
-	*
-	* @return int
-	*/
-	public function hyperlinkSize()
-	{
-	} // hyperlinkSize
-
-	/**
-	* Returns whether sheet is hidden
-	*
-	* @see ExcelSheet::hidden()
-	* @return bool
-	*/
-	public function isHidden()
-	{
-	} //isHidden
-
-	/**
-	* Returns whether LibXL runs in trial or licensed mode
-	*
-	* @return bool
-	*/
-	public function isLicensed()
-	{
-	} //isLicensed
-
-	/**
-	* Returns the header margin (in inches)
-	*
-	* @see ExcelSheet::footerMargin()
-	* @see ExcelSheet::setHeader()
-	* @return float
-	*/
-	public function headerMargin()
-	{
-	} // headerMargin
-
-	/**
-	* Set/Remove horizontal page break
-	*
-	* @param int $row 0-based row number
-	* @param bool $break
-	* @return bool
-	*/
-	public function horPageBreak($row, $break)
-	{
-	} // horPageBreak
-
-	/**
-	* Insert columns from column_start to column_end
-	*
-	* @param int $column_start 0-based column number
-	* @param int $column_end 0-based column number
-	* @param bool $update_named_ranges (optional, default=true)
-	* @return bool
-	*/
-	public function insertCol($column_start, $column_end, $update_named_ranges = true)
-	{
-	} // insertCol
-
-	/**
-	* Insert rows from row_start to row_end
-	*
-	* @param int $row_start 0-based row number
-	* @param int $row_end 0-based row number
-	* @param bool $update_named_ranges (optional, default=true)
-	* @return bool
-	*/
-	public function insertRow($row_start, $row_end, $update_named_ranges = true)
-	{
-	} // insertRow
-
-	/**
-	* Determine if a cell contains a date
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @return bool
-	*/
-	public function isDate($row, $column)
-	{
-	} // isDate
-
-	/**
-	* Determine if a cell contains a formula
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @return bool
-	*/
-	public function isFormula($row, $column)
-	{
-	} // isFormula
-
-	/**
-	* Returns the page orientation mode
-	*
-	* @see ExcelSheet::setLandscape()
-	* @return bool true for landscape, false for portrait
-	*/
-	public function landscape()
-	{
-	} // landscape
-
-	/**
-	* Returns the 0-based last column in a sheet that contains a used cell
-	*
-	* @see ExcelSheet::firstRow()
-	* @see ExcelSheet::lastRow()
-	* @see ExcelSheet::firstCol()
-	* @return int
-	*/
-	public function lastCol()
-	{
-	} // lastCol
-
-	/**
-	* Returns the 0-based last row in a sheet that contains a used cell
-	*
-	* @see ExcelSheet::firstRow()
-	* @see ExcelSheet::firstCol()
-	* @see ExcelSheet::lastCol()
-	* @return int
-	*/
-	public function lastRow()
-	{
-	} // lastRow
-
-	/**
-	* Returns the bottom margin of the sheet (in inches)
-	*
-	* @see ExcelSheet::marginTop()
-	* @see ExcelSheet::marginRight()
-	* @see ExcelSheet::marginLeft()
-	* @see ExcelSheet::setMarginBottom()
-	* @return float
-	*/
-	public function marginBottom()
-	{
-	} // marginBottom
-
-	/**
-	* Returns the left margin of the sheet (in inches)
-	*
-	* @see ExcelSheet::marginTop()
-	* @see ExcelSheet::marginRight()
-	* @see ExcelSheet::marginBottom()
-	* @see ExcelSheet::setMarginLeft()
-	* @return float
-	*/
-	public function marginLeft()
-	{
-	} // marginLeft
-
-	/**
-	* Returns the right margin of the sheet (in inches)
-	*
-	* @see ExcelSheet::marginTop()
-	* @see ExcelSheet::marginLeft()
-	* @see ExcelSheet::marginBottom()
-	* @see ExcelSheet::setMarginRight()
-	* @return float
-	*/
-	public function marginRight()
-	{
-	} // marginRight
-
-	/**
-	* Returns the top margin of the sheet (in inches)
-	*
-	* @see ExcelSheet::marginRight()
-	* @see ExcelSheet::marginLeft()
-	* @see ExcelSheet::marginBottom()
-	* @see ExcelSheet::setMarginTop()
-	* @return float
-	*/
-	public function marginTop()
-	{
-	} // marginTop
-
-	/**
-	* Gets the merged cells by index.
-	*
-	* @param int $index
-	* @return array
-	*/
-	public function merge($index)
-	{
-	} // merge
-
-	/**
-	* Returns a number of merged cells in this worksheet.
-	*
-	* @return int
-	*/
-	public function mergeSize()
-	{
-	} // mergeSize
-
-	/**
-	* Returns the name of the worksheet
-	*
-	* @see ExcelSheet::setName()
-	* @return string
-	*/
-	public function name()
-	{
-	} // name
-
-	/**
-	* Returns the number of named ranges in the sheet.
-	*
-	* @return int
-	*/
-	public function namedRangeSize()
-	{
-	} // namedRangeSize
-
-	/**
-	* Returns the paper size
-	*
-	* @see ExcelSheet::setPaper()
-	* @return int One of ExcelSheet::PAPER_* constants
-	*/
-	public function paper()
-	{
-	} // paper
-
-	/**
-	* Returns whether the gridlines are printed
-	*
-	* @see ExcelSheet::setPrintGridlines()
-	* @return bool
-	*/
-	public function printGridlines()
-	{
-	} // printGridlines
-
-	/**
-	* Returns whether the row and column headers are printed
-	*
-	* @see ExcelSheet::setPrintHeaders()
-	* @return bool
-	*/
-	public function printHeaders()
-	{
-	} // printHeaders
-
-	/**
-	* Returns whether the sheet is protected
-	*
-	* @see ExcelSheet::setProtect()
-	* @return bool
-	*/
-	public function protect()
-	{
-	} // protect
-
-	/**
-	* Read data from a specific cell
-	* An ExcelFormat object will be assigned to $format if passed
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @param &$format (optional, default=null)
-	* @param bool $read_formula (optional, default=true)
-	* @return mixed
-	*/
-	public function read($row, $column, &$format = null, $read_formula = true)
-	{
-	} // read
-
-	/**
-	* Read an entire column worth of data
-	*
-	* @param int $column 0-based column number
-	* @param int $row_start (optional, default=0)
-	* @param int $row_end (optional, default=null)
-	* @param bool $read_formula (optional, default=true)
-	* @return array or false if invalid row/column positions
-	*/
-	public function readCol($column, $row_start = 0, $row_end = null, $read_formula = true)
-	{
-	} // readCol
-
-	/**
-	* Read comment from a cell (only for xls files)
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @return string
-	*/
-	public function readComment($row, $column)
-	{
-	} // readComment
-
-	/**
-	* Read an entire row worth of data
-	*
-	* @param int $row 0-based row number
-	* @param int $column_start (optional, default=0)
-	* @param int $column_end (optional, default=-1)
-	* @param bool $read_formula (optional, default=true)
-	* @return array or false if invalid row/column positions
-	*/
-	public function readRow($row, $column_start = 0, $column_end = -1, $read_formula = true)
-	{
-	} // readRow
-
-	/**
-	* Remove columns from column_start to column_end
-	*
-	* @param int $column_start 0-based column number
-	* @param int $column_end 0-based column number
-	* @param bool $update_named_ranges (optional, default=true)
-	* @return bool
-	*/
-	public function removeCol($column_start, $column_end, $update_named_ranges = true)
-	{
-	} // removeCol
-
-	/**
-	* Removes all data validations for the sheet (only for xlsx files).
-	*
-	* @since libXL 3.8.0.0
-	* @return bool
-	*/
-	public function removeDataValidations()
-	{
-	} // removeDataValidations
-
-	/**
-	* Remove rows from row_start to row_end
-	*
-	* @param int $row_start 0-based row number
-	* @param int $row_end 0-based row number
-	* @param bool $update_named_ranges (optional, default=true)
-	* @return bool
-	*/
-	public function removeRow($row_start, $row_end, $update_named_ranges = true)
-	{
-	} // removeRow
-
-	/**
-	* Converts row and column to a cell reference.
-	*
-	* @param int $row
-	* @param int $column
-	* @param bool $row_relative (optional, default=true)
-	* @param bool $col_relative (optional, default=true)
-	* @return string
-	*/
-	public function rowColToAddr($row, $column, $row_relative = true, $col_relative = true)
-	{
-	} // rowColToAddr
-
-	/**
-	* Returns the row height
-	*
-	* @see ExcelSheet::colWidth()
-	* @see ExcelSheet::colWidthPx()
-	* @see ExcelSheet::setColWidth()
-	* @see ExcelSheet::setRowHeight()
-	* @param int $row 0-based row number
-	* @return float
-	*/
-	public function rowHeight($row)
-	{
-	} // rowHeight
-
-	/**
-	* Returns the row height
-	*
-	* @see ExcelSheet::colWidth()
-	* @see ExcelSheet::colWidthPx()
-	* @see ExcelSheet::setColWidth()
-	* @see ExcelSheet::setRowHeight()
-	* @param int $row 0-based row number
-	* @return float
-	*/
-	public function rowHeightPx($row)
-	{
-	} // rowHeightPx
-
-	/**
-	* Returns whether row is hidden.
-	*
-	* @param int $row 0-based row number
-	* @return bool
-	*/
-	public function rowHidden($row)
-	{
-	} // rowHidden
-
-	/**
-	* Set cell format
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @param ExcelFormat $format
-	* @return void
-	*/
-	public function setCellFormat($row, $column, $format)
-	{
-	} // setCellFormat
-
-	/**
-	* Hides column.
-	*
-	* @param int $column 0-based column number
-	* @param bool $hidden
-	* @return bool
-	*/
-	public function setColHidden($column, $hidden)
-	{
-	} // setColHidden
-
-	/**
-	* Set the width of cells in a column
-	*
-	* @see ExcelSheet::colWidth()
-	* @see ExcelSheet::rowHeight()
-	* @see ExcelSheet::setRowHeight()
-	* @param int $column_start 0-based column number
-	* @param int $column_end 0-based column number
-	* @param float $width (-1: autofit)
-	* @param bool $hidden (optional, default=false)
-	* @param ExcelFormat $format (optional, default=null)
-	* @return bool
-	*/
-	public function setColWidth($column_start, $column_end, $width, $hidden = false, $format = null)
-	{
-	} // setColWidth
-
-	/**
-	* Sets the borders for autofit column widths feature. The method Sheet::setCol()
-	* with -1 width value will affect only to the specified limited area.
-	*
-	* @param int $row_start 0-based row number
-	* @param int $row_end 0-based row number
-	* @param int $column_start 0-based column number
-	* @param int $column_end 0-based column number
-	* @return bool
-	*/
-	public function setAutofitArea($row_start = 0, $row_end = -1, $column_start = 0, $column_end = -1)
-	{
-	} // setAutofitArea
-
-	/**
-	* Sets gridlines for displaying
-	*
-	* @see ExcelSheet::displayGridlines()
-	* @param bool $value
-	* @return void
-	*/
-	public function setDisplayGridlines($value)
-	{
-	} // setDisplayGridlines
-
-	/**
-	* Sets the footer text of the sheet when printed
-	*
-	* @see ExcelSheet::footer()
-	* @see ExcelSheet::header()
-	* @see ExcelSheet::setHeader()
-	* @param string $footer
-	* @param float $margin
-	* @return bool
-	*/
-	public function setFooter($footer, $margin)
-	{
-	} // setFooter
-
-	/**
-	* Sets a flag of grouping rows summary
-	*
-	* @see ExcelSheet::getGroupSummaryBelow()
-	* @see ExcelSheet::getGroupSummaryRight()
-	* @see ExcelSheet::setGroupSummaryRight()
-	* @param bool $direction true=below, false=above
-	* @return bool
-	*/
-	public function setGroupSummaryBelow($direction)
-	{
-	} // setGroupSummaryBelow
-
-	/**
-	* Sets a flag of grouping columns summary
-	*
-	* @see ExcelSheet::getGroupSummaryBelow()
-	* @see ExcelSheet::setGroupSummaryBelow()
-	* @see ExcelSheet::getGroupSummaryRight()
-	* @param bool $direction true=right, false=left
-	* @return bool
-	*/
-	public function setGroupSummaryRight($direction)
-	{
-	} // setGroupSummaryRight
-
-	/**
-	* Sets a flag that the shhet is centered horizontally when printed
-	*
-	* @see ExcelSheet::setVCenter()
-	* @param bool $value
-	* @return void
-	*/
-	public function setHCenter($value)
-	{
-	} // setHCenter
-
-	/**
-	* Hides/unhides the sheet.
-	*
-	* @param bool $value
-	* @return bool
-	*/
-	public function setHidden($value)
-	{
-	} // setHidden
-
-	/**
-	* Set the header text of the sheet when printed
-	*
-	* @see ExcelSheet::setFooter()
-	* @see ExcelSheet::header()
-	* @see ExcelSheet::footer()
-	* @param string $header
-	* @param float $margin
-	* @return bool
-	*/
-	public function setHeader($header, $margin)
-	{
-	} // setHeader
-
-	/**
-	* Sets landscape, or portrait mode for printing
-	*
-	* @see ExcelSheet::landscape()
-	* @param bool $value true for landscape, false for portrait
-	* @return void
-	*/
-	public function setLandscape($value)
-	{
-	} // setLandscape
-
-	/**
-	* Set the bottom margin of the sheet (in inches)
-	*
-	* @see ExcelSheet::setMargingTop()
-	* @see ExcelSheet::setMargingLeft()
-	* @see ExcelSheet::setMargingRight()
-	* @param float $margin
-	* @return void
-	*/
-	public function setMarginBottom($margin)
-	{
-	} // setMarginBottom
-
-	/**
-	* Set the left margin of the sheet (in inches)
-	*
-	* @see ExcelSheet::setMargingTop()
-	* @see ExcelSheet::setMargingRight()
-	* @see ExcelSheet::setMargingBottom()
-	* @param float $margin
-	* @return void
-	*/
-	public function setMarginLeft($margin)
-	{
-	} // setMarginLeft
-
-	/**
-	* Set the right margin of the sheet (in inches)
-	*
-	* @see ExcelSheet::setMargingTop()
-	* @see ExcelSheet::setMargingLeft()
-	* @see ExcelSheet::setMargingBottom()
-	* @param float $margin
-	* @return void
-	*/
-	public function setMarginRight($margin)
-	{
-	} // setMarginRight
-
-	/**
-	* Set the top margin of the sheet (in inches)
-	*
-	* @see ExcelSheet::setMargingLeft()
-	* @see ExcelSheet::setMargingRight()
-	* @see ExcelSheet::setMargingBottom()
-	* @param float $margin
-	* @return void
-	*/
-	public function setMarginTop($margin)
-	{
-	} // setMarginTop
-
-	/**
-	* Set cell merge range
-	*
-	* @param int $row_start 0-based row number
-	* @param int $row_end 0-based row number
-	* @param int $column_start 0-based column number
-	* @param int $column_end 0-based column number
-	* @return bool
-	*/
-	public function setMerge($row_start, $row_end, $column_start, $column_end)
-	{
-	} // setMerge
-
-	/**
-	* Sets the name of the worksheet
-	*
-	* @see ExcelSheet::name()
-	* @param string $name
-	* @return void
-	*/
-	public function setName($name)
-	{
-	} // setName
-
-	/**
-	* Create a named range
-	*
-	* @see ExcelSheet::delNamedRange()
-	* @param string $name
-	* @param int $row_from 0-based row number
-	* @param int $column_from 0-based column number
-	* @param int $row_to 0-based row number
-	* @param int $column_to 0-based column number
-	* @param int $scope_id
-	* @return bool
-	*/
-	public function setNamedRange($name, $row_from, $row_to, $column_from, $column_to, $scope_id = null)
-	{
-	} // setNamedRange
-
-	/**
-	* Sets the paper size
-	*
-	* @see ExcelSheet::paper()
-	* @param int $paper One of ExcelSheet::PAPER_* constants
-	* @return void
-	*/
-	public function setPaper($paper)
-	{
-	} // setPaper
-
-	/**
-	* Fits sheet width and sheet height to wPages and hPages respectively.
-	*
-	* @param int $wPages
-	* @param int $hPages
-	* @return bool
-	*/
-	public function setPrintFit($wPages, $hPages)
-	{
-	} // setPrintFit
-
-	/**
-	* Sets gridlines for printing
-	*
-	* @see ExcelSheet::printGridlines()
-	* @param bool $value
-	* @return void
-	*/
-	public function setPrintGridlines($value)
-	{
-	} // setPrintGridlines
-
-	/**
-	* Sets a flag to indicate row and column headers should be printed
-	*
-	* @see ExcelSheet::printHeaders()
-	* @param bool $value
-	* @return void
-	*/
-	public function setPrintHeaders($value)
-	{
-	} // setPrintHeaders
-
-	/**
-	* Sets repeated columns on each page from column_start to column_end
-	*
-	* @see ExcelSheet::setPrintRepeatRows()
-	* @see ExcelSheet::clearPrintRepeats()
-	* @param int $column_start 0-based column number
-	* @param int $column_end 0-based column number
-	* @return bool
-	*/
-	public function setPrintRepeatCols($column_start, $column_end)
-	{
-	} // setPrintRepeatCols
-
-	/**
-	* Sets the color for the sheet's tab.
-	*
-	* @param int $color - one of the ExcelSheet::COLOR_* constants (optional, default=0)
-	* @return bool
-	*/
-	public function setTabColor($color=0)
-	{
-	} // setTabColor
-
-	/**
-	* Gets repeated columns on each page from colFirst to colLast. Returns false
-	* if repeated columns aren't found.
-	*
-	* @return bool|array with keys "col_start"(int) and "col_end"(int)
-	*/
-	public function printRepeatCols()
-	{
-	} // printRepeatCols
-
-	/**
-	* Sets repeated rows on each page from row_start to row_end
-	*
-	* @see ExcelSheet::setPrintRepeatCols()
-	* @see ExcelSheet::clearPrintRepeats()
-	* @param int $row_start 0-based row number
-	* @param int $row_end 0-based row number
-	* @return bool
-	*/
-	public function setPrintRepeatRows($row_start, $row_end)
-	{
-	} // setPrintRepeatRows
-
-	/**
-	* Gets repeated rows on each page from rowFirst to rowLast. Returns false
-	* if repeated rows aren't found.
-	*
-	* @return bool|array with keys "row_start"(int) and "row_end"(int)
-	*/
-	public function printRepeatRows()
-	{
-	} // printRepeatRows
-
-	/**
-	* Protects or unprotects the worksheet
-	*
-	* @see ExcelSheet::protect()
-	* @param bool $value
-	* @param string $password (optional, default="")
-	* @param int ExcelSheet::PROT_ALL (optional, default=ExcelSheet::PROT_DEFAULT)
-	* @return void
-	*/
-	public function setProtect($value, $password = '', $enhancedProtection = ExcelSheet::PROT_DEFAULT)
-	{
-	} // setProtect
-
-	/**
-	* Sets the right-to-left mode:
-	* 1 - the text is displayed in right-to-left mode,
-	* 0 - the text is displayed in left-to-right mode.
-	*
-	* @param int $mode
-	* @return void
-	*/
-	public function setRightToLeft($mode)
-	{
-	} // setRightToLeft
-
-	/**
-	* Set the height of cells in a row
-	*
-	* @see ExcelSheet::rowHeight()
-	* @see ExcelSheet::colWidth()
-	* @see ExcelSheet::setColWidth()
-	* @param int $row 0-based row number
-	* @param float $height
-	* @param ExcelFormat $format (optional, default=null)
-	* @param bool $hidden (optional, default=false)
-	* @return bool
-	*/
-	public function setRowHeight($row, $height, $format = null, $hidden = false)
-	{
-	} // setRowHeight
-
-	/**
-	* Hides row.
-	*
-	* @param int $row 0-based row number
-	* @param bool $hidden
-	* @return bool
-	*/
-	public function setRowHidden($row, $hidden)
-	{
-	} // setRowHidden
-
-	/**
-	* Sets the first visible row and the leftmost visible column of the sheet.
-	*
-	* @param int $row
-	* @param int $column
-	* @return bool
-	*/
-	public function setTopLeftView($row, $column)
-	{
-	} // setTopLeftView
-
-	/**
-	* Sets a flag that the sheet is centered vertically when printed
-	*
-	* @see ExcelSheet::setHCenter()
-	* @param bool $value
-	* @return void
-	*/
-	public function setVCenter($value)
-	{
-	} // setVCenter
-
-	/**
-	* Sets the zoom level of the current view. 100 is the usual view
-	*
-	* @param int $value
-	* @return void
-	*/
-	public function setZoom($value)
-	{
-	} // setZoom
-
-	/**
-	* Sets the scaling factor for printing (as a percentage)
-	*
-	* @param int $value
-	* @return void
-	*/
-	public function setZoomPrint($value)
-	{
-	} // setZoomPrint
-
-	/**
-	* Gets the split information (position of frozen pane) in the sheet:
-	* row - vertical position of the split;
-	* col - horizontal position of the split.
-	*
-	* @return array
-	*/
-	public function splitInfo()
-	{
-	} // splitInfo
-
-	/**
-	* Split sheet at indicated position
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @return void
-	*/
-	public function splitSheet($row, $column)
-	{
-	} // splitSheet
-
-	/**
-	* Gets the table parameters by index.
-	*
-	* @param int $index (optional, default = 0)
-	* @return array with keys "name"(string), "row_first"(int), "col_first"(int), "row_last"(int), "col_last"(int), "header_row_count"(int) and "totals_row_count"(int)
-	*/
-	public function table($index = 0)
-	{
-	} // table
-
-	/**
-	* Returns the number of tables in the sheet.
-	*
-	* @return int
-	*/
-	public function tableSize()
-	{
-	} // tableSize
-
-	/**
-	* Returns whether the sheet is centered vertically when printed
-	*
-	* @see ExcelSheet::hcenter()
-	* @see ExcelSheet::setVCenter()
-	* @see ExcelSheet::setHCenter()
-	* @return bool
-	*/
-	public function vcenter()
-	{
-	} // vcenter
-
-	/**
-	* Set/Remove vertical page break
-	*
-	* @param int $column 0-based column number
-	* @param bool $break
-	* @return bool
-	*/
-	public function verPageBreak($column, $break)
-	{
-	} // verPageBreak
-
-	/**
-	* Write data into a cell
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @param mixed $data
-	* @param ExcelFormat $format (optional, default=null)
-	* @param int $data_type (optional, default=-1) One of ExcelFormat::AS_* constants
-	* @return bool
-	*/
-	public function write($row, $column, $data, $format = null, $data_type = -1)
-	{
-	} // write
-
-	/**
-	* Write an array of values into a column
-	*
-	* @param int $column 0-based column number
-	* @param array $data
-	* @param int $row_start (optional, default=0)
-	* @param ExcelFormat $format (optional, default=null)
-	* @param int $data_type (optional, default=-1) One of ExcelFormat::AS_* constants
-	* @return bool
-	*/
-	public function writeCol($column, $data, $row_start = 0, $format = null, $data_type = -1)
-	{
-	} // writeCol
-
-	/**
-	* Write comment to a cell (only for xls files)
-	*
-	* @param int $row 0-based row number
-	* @param int $column 0-based column number
-	* @param string $comment
-	* @param string $author
-	* @param int $width
-	* @param int $height
-	* @return void
-	*/
-	public function writeComment($row, $column, $comment, $author, $width, $height)
-	{
-	} // writeComment
-
-	/**
-	* Writes error into the cell with specified format. If format equals 0 then format is ignored.
-	*
-	* @param int $row (optional, default = 0)
-	* @param int $col (optional, default = 0)
-	* @param int $error - one of ExcelSheet::ERRORTYPE_* constants  (optional, default = 0)
-	* @param ExcelFormat $format  (optional, default = null)
-	* @return bool
-	*/
-	public function writeError($row = 0, $col = 0, $error = 0, $format = null)
-	{
-	} // writeError
-
-	/**
-	* Write an array of values into a row
-	*
-	* @param int $row 0-based row number
-	* @param array $data
-	* @param int $column_start (optional, default=0)
-	* @param ExcelFormat $format (optional, default=null)
-	* @return bool
-	*/
-	public function writeRow($row, $data, $column_start = 0, $format = null)
-	{
-	} // writeRow
+    const PAPER_DEFAULT = 0;
+    const PAPER_LETTER = 1;
+    const PAPER_LETTERSMALL = 2;
+    const PAPER_TABLOID = 3;
+    const PAPER_LEDGER = 4;
+    const PAPER_LEGAL = 5;
+    const PAPER_STATEMENT = 6;
+    const PAPER_EXECUTIVE = 7;
+    const PAPER_A3 = 8;
+    const PAPER_A4 = 9;
+    const PAPER_A4SMALL = 10;
+    const PAPER_A5 = 11;
+    const PAPER_B4 = 12;
+    const PAPER_B5 = 13;
+    const PAPER_FOLIO = 14;
+    const PAPER_QUATRO = 15;
+    const PAPER_10x14 = 16;
+    const PAPER_10x17 = 17;
+    const PAPER_NOTE = 18;
+    const PAPER_ENVELOPE_9 = 19;
+    const PAPER_ENVELOPE_10 = 20;
+    const PAPER_ENVELOPE_11 = 21;
+    const PAPER_ENVELOPE_12 = 22;
+    const PAPER_ENVELOPE_14 = 23;
+    const PAPER_C_SIZE = 24;
+    const PAPER_D_SIZE = 25;
+    const PAPER_E_SIZE = 26;
+    const PAPER_ENVELOPE_DL = 27;
+    const PAPER_ENVELOPE_C5 = 28;
+    const PAPER_ENVELOPE_C3 = 29;
+    const PAPER_ENVELOPE_C4 = 30;
+    const PAPER_ENVELOPE_C6 = 31;
+    const PAPER_ENVELOPE_C65 = 32;
+    const PAPER_ENVELOPE_B4 = 33;
+    const PAPER_ENVELOPE_B5 = 34;
+    const PAPER_ENVELOPE_B6 = 35;
+    const PAPER_ENVELOPE = 36;
+    const PAPER_ENVELOPE_MONARCH = 37;
+    const PAPER_US_ENVELOPE = 38;
+    const PAPER_FANFOLD = 39;
+    const PAPER_GERMAN_STD_FANFOLD = 40;
+    const PAPER_GERMAN_LEGAL_FANFOLD = 41;
+
+    const CELLTYPE_EMPTY = 0;
+    const CELLTYPE_NUMBER = 1;
+    const CELLTYPE_STRING = 2;
+    const CELLTYPE_BOOLEAN = 3;
+    const CELLTYPE_BLANK = 4;
+    const CELLTYPE_ERROR = 5;
+
+    const ERRORTYPE_NULL = 0;
+    const ERRORTYPE_DIV_0 = 7;
+    const ERRORTYPE_VALUE = 15;
+    const ERRORTYPE_REF = 23;
+    const ERRORTYPE_NAME = 29;
+    const ERRORTYPE_NUM = 36;
+    const ERRORTYPE_NA = 42;
+    const ERRORTYPE_NOERROR = 255;
+
+    const LEFT_TO_RIGHT = 0;
+    const RIGHT_TO_LEFT = 1;
+
+    const IERR_EVAL_ERROR = 1;
+    const IERR_EMPTY_CELLREF = 2;
+    const IERR_NUMBER_STORED_AS_TEXT = 4;
+    const IERR_INCONSIST_RANGE = 8;
+    const IERR_INCONSIST_FMLA = 16;
+    const IERR_TWODIG_TEXTYEAR = 32;
+    const IERR_UNLOCK_FMLA = 64;
+    const IERR_DATA_VALIDATION = 128;
+
+    const PROT_DEFAULT = -1;
+    const PROT_ALL = 0;
+    const PROT_OBJECTS = 1;
+    const PROT_SCENARIOS = 2;
+    const PROT_FORMAT_CELLS = 4;
+    const PROT_FORMAT_COLUMNS = 8;
+    const PROT_FORMAT_ROWS = 16;
+    const PROT_INSERT_COLUMNS = 32;
+    const PROT_INSERT_ROWS = 64;
+    const PROT_INSERT_HYPERLINKS = 128;
+    const PROT_DELETE_COLUMNS = 256;
+    const PROT_DELETE_ROWS = 512;
+    const PROT_SEL_LOCKED_CELLS = 1024;
+    const PROT_SORT = 2048;
+    const PROT_AUTOFILTER = 4096;
+    const PROT_PIVOTTABLES = 8192;
+    const PROT_SEL_UNLOCKED_CELLS = 16384;
+
+    const SHEETSTATE_VISIBLE = 0;
+    const SHEETSTATE_HIDDEN = 1;
+    const SHEETSTATE_VERYHIDDEN = 2;
+
+    const VALIDATION_TYPE_NONE = 0;
+    const VALIDATION_TYPE_WHOLE = 1;
+    const VALIDATION_TYPE_DECIMAL = 2;
+    const VALIDATION_TYPE_LIST = 3;
+    const VALIDATION_TYPE_DATE = 4;
+    const VALIDATION_TYPE_TIME = 5;
+    const VALIDATION_TYPE_TEXTLENGTH = 6;
+    const VALIDATION_TYPE_CUSTOM = 7;
+
+    const VALIDATION_OP_BETWEEN = 0;
+    const VALIDATION_OP_NOTBETWEEN = 1;
+    const VALIDATION_OP_EQUAL = 2;
+    const VALIDATION_OP_NOTEQUAL = 3;
+    const VALIDATION_OP_LESSTHAN = 4;
+    const VALIDATION_OP_LESSTHANOREQUAL = 5;
+    const VALIDATION_OP_GREATERTHAN = 6;
+    const VALIDATION_OP_GREATERTHANOREQUAL = 7;
+
+    const VALIDATION_ERRSTYLE_STOP = 0; // stop icon in the error alert
+    const VALIDATION_ERRSTYLE_WARNING = 1; // warning icon in the error alert
+    const VALIDATION_ERRSTYLE_INFORMATION = 2; // information icon in the error alert
+
+    /**
+     * Create an ExcelSheet in given Workbook
+     *
+     * @param ExcelBook $book
+     * @param string $name The name for the new worksheet
+     * @return ExcelSheet The worksheet created
+     */
+    public function __construct(ExcelBook $book, $name)
+    {
+    } // __construct
+
+    /**
+     * Adds a data validation for the specified range (only for xlsx files).
+     *
+     * @param int $type - one of the ExcelSheet::VALIDATION_TYPE_* constants
+     * @param int $op - one of the ExcelSheet::VALIDATION_OP_* constants
+     * @param int $row_first 0-based
+     * @param int $row_last 0-based
+     * @param int $col_first 0-based
+     * @param int $col_last 0-based
+     * @param string $val_1 the first value for relational operator
+     * @param string $val_2 the second value for VALIDATION_OP_BETWEEN or VALIDATION_OP_NOTBETWEEN operator
+     * @param bool $allow_blank (optional, default = true) a boolean value indicating whether the data validation treats empty or blank entries as valid, 'true' means empty entries are OK and do not violate the validation constraints
+     * @param bool $hide_dropdown (optional, default = false) a boolean value indicating whether to display the dropdown combo box for a list type data validation (ExcelSheet::VALIDATION_TYPE_LIST)
+     * @param bool $show_inputmessage (optional, default = true) a boolean value indicating whether to display the input prompt message
+     * @param bool $show_errormessage (optional, default = true) a boolean value indicating whether to display the error alert message when an invalid value has been entered, according to the criteria specified
+     * @param string $prompt_title (optional, default = '') title bar text of input prompt
+     * @param string $prompt (optional, default = '') message text of input prompt
+     * @param string $error_title (optional, default = '') title bar text of error alert
+     * @param string $error (optional, default = '') message text of error alert
+     * @param int $error_style - (optional, default = \ExcelSheet::VALIDATION_ERRSTYLE_WARNING) one of the ExcelSheet::VALIDATION_ERRSTYLE_* constants
+     * @since libXL 3.8.0.0
+     */
+    public function addDataValidation($type, $op, $row_first, $row_last, $col_first, $col_last, $val_1, $val_2 = null, $allow_blank = true, $hide_dropdown = false, $show_inputmessage = true, $show_errormessage = true, $prompt_title = '', $prompt = '', $error_title = '', $error = '', $error_style = \ExcelSheet::VALIDATION_ERRSTYLE_WARNING)
+    {
+    } // addDataValidation
+
+    /**
+     * Adds a data validation for the specified range with double or date values for the relational
+     * operator (only for xlsx files).
+     *
+     * @param int $type - one of the ExcelSheet::VALIDATION_TYPE_* constants
+     * @param int $op - one of the ExcelSheet::VALIDATION_OP_* constants
+     * @param int $row_first 0-based
+     * @param int $row_last 0-based
+     * @param int $col_first 0-based
+     * @param int $col_last 0-based
+     * @param float $val_1 the first value for relational operator
+     * @param float $val_2 the second value for VALIDATION_OP_BETWEEN or VALIDATION_OP_NOTBETWEEN operator
+     * @param bool $allow_blank (optional, default = true) a boolean value indicating whether the data validation treats empty or blank entries as valid, 'true' means empty entries are OK and do not violate the validation constraints
+     * @param bool $hide_dropdown (optional, default = false) a boolean value indicating whether to display the dropdown combo box for a list type data validation (ExcelSheet::VALIDATION_TYPE_LIST)
+     * @param bool $show_inputmessage (optional, default = true) a boolean value indicating whether to display the input prompt message
+     * @param bool $show_errormessage (optional, default = true) a boolean value indicating whether to display the error alert message when an invalid value has been entered, according to the criteria specified
+     * @param string $prompt_title (optional, default = '') title bar text of input prompt
+     * @param string $prompt (optional, default = '') message text of input prompt
+     * @param string $error_title (optional, default = '') title bar text of error alert
+     * @param string $error (optional, default = '') message text of error alert
+     * @param int $error_style - (optional, default = \ExcelSheet::VALIDATION_ERRSTYLE_WARNING) one of the ExcelSheet::VALIDATION_ERRSTYLE_* constants
+     * @since libXL 3.8.0.0
+     */
+    public function addDataValidationDouble($type, $op, $row_first, $row_last, $col_first, $col_last, $val_1, $val_2 = null, $allow_blank = true, $hide_dropdown = false, $show_inputmessage = true, $show_errormessage = true, $prompt_title = '', $prompt = '', $error_title = '', $error = '', $error_style = \ExcelSheet::VALIDATION_ERRSTYLE_WARNING)
+    {
+    } // addDataValidationDouble
+
+    /**
+     * Adds the new hyperlink.
+     *
+     * @param string $hyperlink
+     * @param int $row_first 0-based
+     * @param int $row_last 0-based
+     * @param int $col_first 0-based
+     * @param int $col_last 0-based
+     * @return void
+     */
+    public function addHyperlink($hyperlink, $row_first, $row_last, $col_first, $col_last)
+    {
+    } // addHyperlink
+
+    /**
+     * Adds the ignored error for specified range. It allows to hide green triangles on left sides of cells.
+     *
+     * @param int $error - one of the ExcelSheet::IERR_* constants
+     * @param int $row_first 0-based (optional, default = 0)
+     * @param int $col_first 0-based (optional, default = 0)
+     * @param int $row_last 0-based (optional, default = 0)
+     * @param int $col_last 0-based (optional, default = 0)
+     * @return bool
+     */
+    public function addIgnoredError($error, $row_first = 0, $col_first = 0, $row_last = 0, $col_last = 0)
+    {
+    } // addIgnoredError
+
+    /**
+     * Insert a picture into a cell with given dimensions
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @param int $picture_id Value returned by ExcelBook::addPictureFrom*() methods
+     * @param int $width
+     * @param int $height
+     * @param int $x_offset (optional, default=0)
+     * @param int $y_offset (optional, default=0)
+     * @return void
+     * @see ExcelBook::addPictureFromString()
+     * @see ExcelBook::addPictureFromFile()
+     * @see ExcelSheet::addPictureScaled()
+     */
+    public function addPictureDim($row, $column, $picture_id, $width, $height, $x_offset = 0, $y_offset = 0)
+    {
+    } // addPictureDim
+
+    /**
+     * Insert a picture into a cell with a set scale
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @param int $picture_id Value returned by ExcelBook::addPictureFrom*() methods
+     * @param float $scale
+     * @param int $x_offset (optional, default = 0)
+     * @param int $y_offset (optional, default = 0)
+     * @return void
+     * @see ExcelBook::addPictureFromString()
+     * @see ExcelBook::addPictureFromFile()
+     * @see ExcelSheet::addPictureDim()
+     */
+    public function addPictureScaled($row, $column, $picture_id, $scale, $x_offset = 0, $y_offset = 0)
+    {
+    } // addPictureScaled
+
+    /**
+     * Converts a cell reference to row and column.
+     *
+     * @param string $cell_reference
+     * @return array with keys "row"(int), "column"(int), "col_relative"(bool), "row_relative"(bool)
+     */
+    public function addrToRowCol($cell_reference)
+    {
+    } // addrToRowCol
+
+    /**
+     * Returns the AutoFilter. Creates it if it doesn't exist.
+     *
+     * @return ExcelAutoFilter
+     */
+    public function autoFilter()
+    {
+    } // autoFilter
+
+    /**
+     * Applies the AutoFilter to the sheet.
+     *
+     * @return bool
+     */
+    public function applyFilter()
+    {
+    } // applyFilter
+
+    /**
+     * Removes the AutoFilter from the sheet.
+     *
+     * @return bool
+     */
+    public function removeFilter()
+    {
+    } // removeFilter
+
+    /**
+     * Get the cell format
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @return ExcelFormat
+     */
+    public function cellFormat($row, $column)
+    {
+    } // cellFormat
+
+    /**
+     * Get the cell type
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @return int One of ExcelSheet::CELLTYPE_* constants
+     */
+    public function cellType($row, $column)
+    {
+    } // cellType
+
+    /**
+     * Clear cells in the specified area
+     *
+     * @param int $row_start 0-based row number
+     * @param int $row_end 0-based row number
+     * @param int $column_start 0-based column number
+     * @param int $column_end 0-based column number
+     * @return void
+     */
+    public function clear($row_start, $row_end, $column_start, $column_end)
+    {
+    } // clear
+
+    /**
+     * Sets the print area.
+     *
+     * @param int $row_start 0-based row number
+     * @param int $row_end 0-based row number
+     * @param int $column_start 0-based column number
+     * @param int $column_end 0-based column number
+     * @return bool
+     */
+    public function setPrintArea($row_start, $row_end, $column_start, $column_end)
+    {
+    } // setPrintArea
+
+    /**
+     * Gets the print area. Returns false if print area isn't found.
+     *
+     * @return bool|array with keys "row_start"(int), "row_end"(int), "col_start"(int) and "col_end"(int)
+     */
+    public function printArea()
+    {
+    } // printArea
+
+    /**
+     * Clears the print area
+     *
+     * @return bool
+     */
+    public function clearPrintArea()
+    {
+    } // clearPrintArea
+
+    /**
+     * Clears repeated rows and columns on each page
+     *
+     * @return bool
+     * @see ExcelSheet::setPrintRepeatCols()
+     * @see ExcelSheet::setPrintRepeatRows()
+     */
+    public function clearPrintRepeats()
+    {
+    } // clearPrintRepeats
+
+    /**
+     * Returns whether column is hidden.
+     *
+     * @param int $column 0-based column number
+     * @return bool
+     */
+    public function colHidden($column)
+    {
+    } // colHidden
+
+    /**
+     * Returns the cell width
+     *
+     * @param int $column 0-based column number
+     * @return float
+     * @see ExcelSheet::setColWidth()
+     * @see ExcelSheet::setRowHeight()
+     * @see ExcelSheet::rowHeight()
+     * @see ExcelSheet::colWidthPx()
+     */
+    public function colWidth($column)
+    {
+    } // colWidth
+
+    /**
+     * Returns the cell width
+     *
+     * @param int $column 0-based column number
+     * @return float
+     * @see ExcelSheet::setColWidth()
+     * @see ExcelSheet::setRowHeight()
+     * @see ExcelSheet::rowHeight()
+     * @see ExcelSheet::colWidth()
+     */
+    public function colWidthPx($column)
+    {
+    } // colWidthPx
+
+    /**
+     * Copy a cell from one location to another
+     *
+     * @param int $row_from 0-based row number
+     * @param int $column_from 0-based column number
+     * @param int $row_to 0-based row number
+     * @param int $column_to 0-based column number
+     * @return void
+     */
+    public function copy($row_from, $column_from, $row_to, $column_to)
+    {
+    } // copy
+
+    /**
+     * Removes hyperlink by index.
+     *
+     * @param int $index
+     * @return bool
+     */
+    public function delHyperlink($index)
+    {
+    } // delHyperlink
+
+    /**
+     * Delete a named range
+     *
+     * @param string $name
+     * @param int $scope_id
+     * @return bool
+     * @see ExcelSheet::setNamedRange()
+     */
+    public function delNamedRange($name, $scope_id = null)
+    {
+    } // delNamedRange
+
+    /**
+     * Delete cell merge
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @return bool
+     */
+    public function deleteMerge($row, $column)
+    {
+    } // deleteMerge
+
+    /**
+     * Removes merged cells by index.
+     *
+     * @param int $index
+     * @return bool
+     */
+    public function delMergeByIndex($index)
+    {
+    } // delMergeByIndex
+
+    /**
+     * Returns whether the gridlines are displayed
+     *
+     * @return bool
+     * @see ExcelSheet::setDisplayGridlines()
+     */
+    public function displayGridlines()
+    {
+    } // displayGridlines
+
+    /**
+     * Returns the 0-based first column in a sheet that contains a used cell
+     *
+     * @return int
+     * @see ExcelSheet::lastRow()
+     * @see ExcelSheet::lastCol()
+     * @see ExcelSheet::firstRow()
+     */
+    public function firstCol()
+    {
+    } // firstCol
+
+    /**
+     * Returns the 0-based first row in a sheet that contains a used cell
+     *
+     * @return int
+     * @see ExcelSheet::firstCol()
+     * @see ExcelSheet::lastCol()
+     * @see ExcelSheet::lastRow()
+     */
+    public function firstRow()
+    {
+    } // firstRow
+
+    /**
+     * Returns the footer text of the sheet when printed
+     *
+     * @return string
+     * @see ExcelSheet::setFooter()
+     * @see ExcelSheet::setHeader()
+     * @see ExcelSheet::header()
+     */
+    public function footer()
+    {
+    } // footer
+
+    /**
+     * Returns the footer margin (in inches)
+     *
+     * @return float
+     * @see ExcelSheet::headerMargin()
+     * @see ExcelSheet::setFooter()
+     */
+    public function footerMargin()
+    {
+    } // footerMargin
+
+    /**
+     * Returns whether grouping rows summary is below, or above
+     *
+     * @return bool true=below, false=above
+     * @see ExcelSheet::getGroupSummaryRight()
+     * @see ExcelSheet::setGroupSummaryRight()
+     * @see ExcelSheet::setGroupSummaryBelow()
+     */
+    public function getGroupSummaryBelow()
+    {
+    } // getGroupSummaryBelow
+
+    /**
+     * Returns whether grouping columns summary is right, or left
+     *
+     * @return bool true=right, false=left
+     * @see ExcelSheet::setGroupSummaryBelow()
+     * @see ExcelSheet::setGroupSummaryRight()
+     * @see ExcelSheet::getGroupSummaryBelow()
+     */
+    public function getGroupSummaryRight()
+    {
+    } // getGroupSummaryRight
+
+    /**
+     * Returns column with horizontal page break at position index.
+     *
+     * @param int $index
+     * @return int
+     */
+    public function getHorPageBreak($index)
+    {
+    } // getHorPageBreak
+
+    /**
+     * Returns a number of horizontal page breaks in the sheet.
+     *
+     * @return int
+     */
+    public function getHorPageBreakSize()
+    {
+    } // getHorPageBreakSize
+
+    /**
+     * Gets the named range coordinates by index.
+     *
+     * @param int $index
+     * @param int $scope_id (optional, default = null) index of sheet or -1 for Workbook
+     * @return array with keys "row_first"(int), "row_last"(int), "col_first"(int), "col_last"(int), "hidden"(bool), "scope"(int)
+     */
+    public function getIndexRange($index, $scope_id = null)
+    {
+    } // getIndexRange
+
+    /**
+     * Get cell merge range
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @return array Four integers as keys "row_first", "row_last", "col_first", and "col_last"
+     */
+    public function getMerge($row, $column)
+    {
+    } // getMerge
+
+    /**
+     * Gets the named range coordinates by name, returns false if range is not found.
+     *
+     * @param string $name
+     * @param int $scope_id (optional, default=null)
+     * @return array with keys "row_first"(int), "row_last"(int), "col_first"(int), "col_last"(int), "hidden"(bool)
+     */
+    public function getNamedRange($name, $scope_id = null)
+    {
+    } // getNamedRange
+
+    /**
+     * Returns a number of pictures in this worksheet.
+     *
+     * @return int
+     */
+    public function getNumPictures()
+    {
+    } // getNumPictures
+
+    /**
+     * Returns a information about a workbook picture at position index in worksheet.
+     *
+     * @param int $index
+     * @return array with keys "picture_index"(int), "row_top"(int), "col_left"(int), "row_bottom"(int), "col_right"(int), "width"(int), "height"(int), "offset_x"(int), "offset_y"(int)
+     */
+    public function getPictureInfo($index)
+    {
+    } // getPictureInfo
+
+    /**
+     * Returns whether fit to page option is enabled, and if so to what width & height
+     *
+     * @return array with keys "width"(int), "height"(int)
+     */
+    public function getPrintFit()
+    {
+    } // getPrintFit
+
+    /**
+     * Returns whether the text is displayed in right-to-left mode: 1 - yes, 0 - no.
+     *
+     * @return int
+     */
+    public function getRightToLeft()
+    {
+    } // getRightToLeft
+
+    /**
+     * Extracts the first visible row and the leftmost visible column of the sheet.
+     *
+     * @return array with keys "row"(int), "column"(int)
+     */
+    public function getTopLeftView()
+    {
+    } // getTopLeftView
+
+    /**
+     * Returns column with vertical page break at position index.
+     *
+     * @param int $index
+     * @return int
+     */
+    public function getVerPageBreak($index)
+    {
+    } // getVerPageBreak
+
+    /**
+     * Returns a number of vertical page breaks in the sheet.
+     *
+     * @return int
+     */
+    public function getVerPageBreakSize()
+    {
+    } // getVerPageBreakSize
+
+    /**
+     * Group columns from $column_start to $column_end
+     *
+     * @param int $column_start 0-based column number
+     * @param int $column_end 0-based column number
+     * @param bool $collapse (optional, default = false)
+     * @return bool
+     */
+    public function groupCols($column_start, $column_end, $collapse = false)
+    {
+    } // groupCols
+
+    /**
+     * Group rows from $row_start to $row_end
+     *
+     * @param int $row_start 0-based row number
+     * @param int $row_end 0-based row number
+     * @param bool $collapse (optional, default = false)
+     * @return bool
+     */
+    public function groupRows($row_start, $row_end, $collapse = false)
+    {
+    } // groupRows
+
+    /**
+     * Returns whether the sheet is centered horizontally when printed
+     *
+     * @return bool
+     * @see ExcelSheet::setHCenter()
+     * @see ExcelSheet::setVCenter()
+     * @see ExcelSheet::vcenter()
+     */
+    public function hcenter()
+    {
+    } // hcenter
+
+    /**
+     * Returns the header text of the sheet when printed
+     *
+     * @return string
+     * @see ExcelSheet::footer()
+     * @see ExcelSheet::setFooter()
+     * @see ExcelSheet::setHeader()
+     */
+    public function header()
+    {
+    } // header
+
+    /**
+     * Hides/unhides the sheet
+     *
+     * @param bool $hide
+     * @return bool
+     * @deprecated
+     */
+    public function hidden($hide)
+    {
+    } // hidden
+
+    /**
+     * Gets the hyperlink and its coordinates by index.
+     *
+     * @param int $index
+     * @return array
+     */
+    public function hyperlink($index)
+    {
+    } // hyperlink
+
+    /**
+     * Returns the number of hyperlinks in the sheet.
+     *
+     * @return int
+     */
+    public function hyperlinkSize()
+    {
+    } // hyperlinkSize
+
+    /**
+     * Returns whether sheet is hidden
+     *
+     * @return bool
+     * @see ExcelSheet::hidden()
+     */
+    public function isHidden()
+    {
+    } //isHidden
+
+    /**
+     * Returns whether LibXL runs in trial or licensed mode
+     *
+     * @return bool
+     */
+    public function isLicensed()
+    {
+    } //isLicensed
+
+    /**
+     * Returns the header margin (in inches)
+     *
+     * @return float
+     * @see ExcelSheet::setHeader()
+     * @see ExcelSheet::footerMargin()
+     */
+    public function headerMargin()
+    {
+    } // headerMargin
+
+    /**
+     * Set/Remove horizontal page break
+     *
+     * @param int $row 0-based row number
+     * @param bool $break
+     * @return bool
+     */
+    public function horPageBreak($row, $break)
+    {
+    } // horPageBreak
+
+    /**
+     * Insert columns from column_start to column_end
+     *
+     * @param int $column_start 0-based column number
+     * @param int $column_end 0-based column number
+     * @param bool $update_named_ranges (optional, default=true)
+     * @return bool
+     */
+    public function insertCol($column_start, $column_end, $update_named_ranges = true)
+    {
+    } // insertCol
+
+    /**
+     * Insert rows from row_start to row_end
+     *
+     * @param int $row_start 0-based row number
+     * @param int $row_end 0-based row number
+     * @param bool $update_named_ranges (optional, default=true)
+     * @return bool
+     */
+    public function insertRow($row_start, $row_end, $update_named_ranges = true)
+    {
+    } // insertRow
+
+    /**
+     * Determine if a cell contains a date
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @return bool
+     */
+    public function isDate($row, $column)
+    {
+    } // isDate
+
+    /**
+     * Determine if a cell contains a formula
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @return bool
+     */
+    public function isFormula($row, $column)
+    {
+    } // isFormula
+
+    /**
+     * Returns the page orientation mode
+     *
+     * @return bool true for landscape, false for portrait
+     * @see ExcelSheet::setLandscape()
+     */
+    public function landscape()
+    {
+    } // landscape
+
+    /**
+     * Returns the 0-based last column in a sheet that contains a used cell
+     *
+     * @return int
+     * @see ExcelSheet::lastRow()
+     * @see ExcelSheet::firstCol()
+     * @see ExcelSheet::firstRow()
+     */
+    public function lastCol()
+    {
+    } // lastCol
+
+    /**
+     * Returns the 0-based last row in a sheet that contains a used cell
+     *
+     * @return int
+     * @see ExcelSheet::firstCol()
+     * @see ExcelSheet::lastCol()
+     * @see ExcelSheet::firstRow()
+     */
+    public function lastRow()
+    {
+    } // lastRow
+
+    /**
+     * Returns the bottom margin of the sheet (in inches)
+     *
+     * @return float
+     * @see ExcelSheet::marginRight()
+     * @see ExcelSheet::marginLeft()
+     * @see ExcelSheet::setMarginBottom()
+     * @see ExcelSheet::marginTop()
+     */
+    public function marginBottom()
+    {
+    } // marginBottom
+
+    /**
+     * Returns the left margin of the sheet (in inches)
+     *
+     * @return float
+     * @see ExcelSheet::marginRight()
+     * @see ExcelSheet::marginBottom()
+     * @see ExcelSheet::setMarginLeft()
+     * @see ExcelSheet::marginTop()
+     */
+    public function marginLeft()
+    {
+    } // marginLeft
+
+    /**
+     * Returns the right margin of the sheet (in inches)
+     *
+     * @return float
+     * @see ExcelSheet::marginLeft()
+     * @see ExcelSheet::marginBottom()
+     * @see ExcelSheet::setMarginRight()
+     * @see ExcelSheet::marginTop()
+     */
+    public function marginRight()
+    {
+    } // marginRight
+
+    /**
+     * Returns the top margin of the sheet (in inches)
+     *
+     * @return float
+     * @see ExcelSheet::marginLeft()
+     * @see ExcelSheet::marginBottom()
+     * @see ExcelSheet::setMarginTop()
+     * @see ExcelSheet::marginRight()
+     */
+    public function marginTop()
+    {
+    } // marginTop
+
+    /**
+     * Gets the merged cells by index.
+     *
+     * @param int $index
+     * @return array
+     */
+    public function merge($index)
+    {
+    } // merge
+
+    /**
+     * Returns a number of merged cells in this worksheet.
+     *
+     * @return int
+     */
+    public function mergeSize()
+    {
+    } // mergeSize
+
+    /**
+     * Returns the name of the worksheet
+     *
+     * @return string
+     * @see ExcelSheet::setName()
+     */
+    public function name()
+    {
+    } // name
+
+    /**
+     * Returns the number of named ranges in the sheet.
+     *
+     * @return int
+     */
+    public function namedRangeSize()
+    {
+    } // namedRangeSize
+
+    /**
+     * Returns the paper size
+     *
+     * @return int One of ExcelSheet::PAPER_* constants
+     * @see ExcelSheet::setPaper()
+     */
+    public function paper()
+    {
+    } // paper
+
+    /**
+     * Returns whether the gridlines are printed
+     *
+     * @return bool
+     * @see ExcelSheet::setPrintGridlines()
+     */
+    public function printGridlines()
+    {
+    } // printGridlines
+
+    /**
+     * Returns whether the row and column headers are printed
+     *
+     * @return bool
+     * @see ExcelSheet::setPrintHeaders()
+     */
+    public function printHeaders()
+    {
+    } // printHeaders
+
+    /**
+     * Returns whether the sheet is protected
+     *
+     * @return bool
+     * @see ExcelSheet::setProtect()
+     */
+    public function protect()
+    {
+    } // protect
+
+    /**
+     * Read data from a specific cell
+     * An ExcelFormat object will be assigned to $format if passed
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @param &$format (optional, default=null)
+     * @param bool $read_formula (optional, default=true)
+     * @return mixed
+     */
+    public function read($row, $column, &$format = null, $read_formula = true)
+    {
+    } // read
+
+    /**
+     * Read an entire column worth of data
+     *
+     * @param int $column 0-based column number
+     * @param int $row_start (optional, default=0)
+     * @param int $row_end (optional, default=null)
+     * @param bool $read_formula (optional, default=true)
+     * @return array or false if invalid row/column positions
+     */
+    public function readCol($column, $row_start = 0, $row_end = null, $read_formula = true)
+    {
+    } // readCol
+
+    /**
+     * Read comment from a cell (only for xls files)
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @return string
+     */
+    public function readComment($row, $column)
+    {
+    } // readComment
+
+    /**
+     * Read an entire row worth of data
+     *
+     * @param int $row 0-based row number
+     * @param int $column_start (optional, default=0)
+     * @param int $column_end (optional, default=-1)
+     * @param bool $read_formula (optional, default=true)
+     * @return array or false if invalid row/column positions
+     */
+    public function readRow($row, $column_start = 0, $column_end = -1, $read_formula = true)
+    {
+    } // readRow
+
+    /**
+     * Remove columns from column_start to column_end
+     *
+     * @param int $column_start 0-based column number
+     * @param int $column_end 0-based column number
+     * @param bool $update_named_ranges (optional, default=true)
+     * @return bool
+     */
+    public function removeCol($column_start, $column_end, $update_named_ranges = true)
+    {
+    } // removeCol
+
+    /**
+     * Removes all data validations for the sheet (only for xlsx files).
+     *
+     * @return bool
+     * @since libXL 3.8.0.0
+     */
+    public function removeDataValidations()
+    {
+    } // removeDataValidations
+
+    /**
+     * Remove rows from row_start to row_end
+     *
+     * @param int $row_start 0-based row number
+     * @param int $row_end 0-based row number
+     * @param bool $update_named_ranges (optional, default=true)
+     * @return bool
+     */
+    public function removeRow($row_start, $row_end, $update_named_ranges = true)
+    {
+    } // removeRow
+
+    /**
+     * Converts row and column to a cell reference.
+     *
+     * @param int $row
+     * @param int $column
+     * @param bool $row_relative (optional, default=true)
+     * @param bool $col_relative (optional, default=true)
+     * @return string
+     */
+    public function rowColToAddr($row, $column, $row_relative = true, $col_relative = true)
+    {
+    } // rowColToAddr
+
+    /**
+     * Returns the row height
+     *
+     * @param int $row 0-based row number
+     * @return float
+     * @see ExcelSheet::setColWidth()
+     * @see ExcelSheet::setRowHeight()
+     * @see ExcelSheet::colWidth()
+     * @see ExcelSheet::colWidthPx()
+     */
+    public function rowHeight($row)
+    {
+    } // rowHeight
+
+    /**
+     * Returns the row height
+     *
+     * @param int $row 0-based row number
+     * @return float
+     * @see ExcelSheet::setColWidth()
+     * @see ExcelSheet::setRowHeight()
+     * @see ExcelSheet::colWidth()
+     * @see ExcelSheet::colWidthPx()
+     */
+    public function rowHeightPx($row)
+    {
+    } // rowHeightPx
+
+    /**
+     * Returns whether row is hidden.
+     *
+     * @param int $row 0-based row number
+     * @return bool
+     */
+    public function rowHidden($row)
+    {
+    } // rowHidden
+
+    /**
+     * Set cell format
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @param ExcelFormat $format
+     * @return void
+     */
+    public function setCellFormat($row, $column, $format)
+    {
+    } // setCellFormat
+
+    /**
+     * Hides column.
+     *
+     * @param int $column 0-based column number
+     * @param bool $hidden
+     * @return bool
+     */
+    public function setColHidden($column, $hidden)
+    {
+    } // setColHidden
+
+    /**
+     * Set the width of cells in a column
+     *
+     * @param int $column_start 0-based column number
+     * @param int $column_end 0-based column number
+     * @param float $width (-1: autofit)
+     * @param bool $hidden (optional, default=false)
+     * @param ExcelFormat $format (optional, default=null)
+     * @return bool
+     * @see ExcelSheet::colWidth()
+     * @see ExcelSheet::rowHeight()
+     * @see ExcelSheet::setRowHeight()
+     */
+    public function setColWidth($column_start, $column_end, $width, $hidden = false, $format = null)
+    {
+    } // setColWidth
+
+    /**
+     * Sets the borders for autofit column widths feature. The method Sheet::setCol()
+     * with -1 width value will affect only to the specified limited area.
+     *
+     * @param int $row_start 0-based row number
+     * @param int $row_end 0-based row number
+     * @param int $column_start 0-based column number
+     * @param int $column_end 0-based column number
+     * @return bool
+     */
+    public function setAutofitArea($row_start = 0, $row_end = -1, $column_start = 0, $column_end = -1)
+    {
+    } // setAutofitArea
+
+    /**
+     * Sets gridlines for displaying
+     *
+     * @param bool $value
+     * @return void
+     * @see ExcelSheet::displayGridlines()
+     */
+    public function setDisplayGridlines($value)
+    {
+    } // setDisplayGridlines
+
+    /**
+     * Sets the footer text of the sheet when printed
+     *
+     * @param string $footer
+     * @param float $margin
+     * @return bool
+     * @see ExcelSheet::footer()
+     * @see ExcelSheet::header()
+     * @see ExcelSheet::setHeader()
+     */
+    public function setFooter($footer, $margin)
+    {
+    } // setFooter
+
+    /**
+     * Sets a flag of grouping rows summary
+     *
+     * @param bool $direction true=below, false=above
+     * @return bool
+     * @see ExcelSheet::setGroupSummaryRight()
+     * @see ExcelSheet::getGroupSummaryBelow()
+     * @see ExcelSheet::getGroupSummaryRight()
+     */
+    public function setGroupSummaryBelow($direction)
+    {
+    } // setGroupSummaryBelow
+
+    /**
+     * Sets a flag of grouping columns summary
+     *
+     * @param bool $direction true=right, false=left
+     * @return bool
+     * @see ExcelSheet::getGroupSummaryRight()
+     * @see ExcelSheet::getGroupSummaryBelow()
+     * @see ExcelSheet::setGroupSummaryBelow()
+     */
+    public function setGroupSummaryRight($direction)
+    {
+    } // setGroupSummaryRight
+
+    /**
+     * Sets a flag that the sheet is centered horizontally when printed
+     *
+     * @param bool $value
+     * @return void
+     * @see ExcelSheet::setVCenter()
+     */
+    public function setHCenter($value)
+    {
+    } // setHCenter
+
+    /**
+     * Hides/unhides the sheet.
+     *
+     * @param bool $value
+     * @return bool
+     */
+    public function setHidden($value)
+    {
+    } // setHidden
+
+    /**
+     * Set the header text of the sheet when printed
+     *
+     * @param string $header
+     * @param float $margin
+     * @return bool
+     * @see ExcelSheet::setFooter()
+     * @see ExcelSheet::header()
+     * @see ExcelSheet::footer()
+     */
+    public function setHeader($header, $margin)
+    {
+    } // setHeader
+
+    /**
+     * Sets landscape, or portrait mode for printing
+     *
+     * @param bool $value true for landscape, false for portrait
+     * @return void
+     * @see ExcelSheet::landscape()
+     */
+    public function setLandscape($value)
+    {
+    } // setLandscape
+
+    /**
+     * Set the bottom margin of the sheet (in inches)
+     *
+     * @param float $margin
+     * @return void
+     * @see ExcelSheet::setMargingRight()
+     * @see ExcelSheet::setMargingTop()
+     * @see ExcelSheet::setMargingLeft()
+     */
+    public function setMarginBottom($margin)
+    {
+    } // setMarginBottom
+
+    /**
+     * Set the left margin of the sheet (in inches)
+     *
+     * @param float $margin
+     * @return void
+     * @see ExcelSheet::setMargingBottom()
+     * @see ExcelSheet::setMargingTop()
+     * @see ExcelSheet::setMargingRight()
+     */
+    public function setMarginLeft($margin)
+    {
+    } // setMarginLeft
+
+    /**
+     * Set the right margin of the sheet (in inches)
+     *
+     * @param float $margin
+     * @return void
+     * @see ExcelSheet::setMargingBottom()
+     * @see ExcelSheet::setMargingTop()
+     * @see ExcelSheet::setMargingLeft()
+     */
+    public function setMarginRight($margin)
+    {
+    } // setMarginRight
+
+    /**
+     * Set the top margin of the sheet (in inches)
+     *
+     * @param float $margin
+     * @return void
+     * @see ExcelSheet::setMargingBottom()
+     * @see ExcelSheet::setMargingLeft()
+     * @see ExcelSheet::setMargingRight()
+     */
+    public function setMarginTop($margin)
+    {
+    } // setMarginTop
+
+    /**
+     * Set cell merge range
+     *
+     * @param int $row_start 0-based row number
+     * @param int $row_end 0-based row number
+     * @param int $column_start 0-based column number
+     * @param int $column_end 0-based column number
+     * @return bool
+     */
+    public function setMerge($row_start, $row_end, $column_start, $column_end)
+    {
+    } // setMerge
+
+    /**
+     * Sets the name of the worksheet
+     *
+     * @param string $name
+     * @return void
+     * @see ExcelSheet::name()
+     */
+    public function setName($name)
+    {
+    } // setName
+
+    /**
+     * Create a named range
+     *
+     * @param string $name
+     * @param int $row_from 0-based row number
+     * @param int $column_from 0-based column number
+     * @param int $row_to 0-based row number
+     * @param int $column_to 0-based column number
+     * @param int $scope_id
+     * @return bool
+     * @see ExcelSheet::delNamedRange()
+     */
+    public function setNamedRange($name, $row_from, $row_to, $column_from, $column_to, $scope_id = null)
+    {
+    } // setNamedRange
+
+    /**
+     * Sets the paper size
+     *
+     * @param int $paper One of ExcelSheet::PAPER_* constants
+     * @return void
+     * @see ExcelSheet::paper()
+     */
+    public function setPaper($paper)
+    {
+    } // setPaper
+
+    /**
+     * Fits sheet width and sheet height to wPages and hPages respectively.
+     *
+     * @param int $wPages
+     * @param int $hPages
+     * @return bool
+     */
+    public function setPrintFit($wPages, $hPages)
+    {
+    } // setPrintFit
+
+    /**
+     * Sets gridlines for printing
+     *
+     * @param bool $value
+     * @return void
+     * @see ExcelSheet::printGridlines()
+     */
+    public function setPrintGridlines($value)
+    {
+    } // setPrintGridlines
+
+    /**
+     * Sets a flag to indicate row and column headers should be printed
+     *
+     * @param bool $value
+     * @return void
+     * @see ExcelSheet::printHeaders()
+     */
+    public function setPrintHeaders($value)
+    {
+    } // setPrintHeaders
+
+    /**
+     * Sets repeated columns on each page from column_start to column_end
+     *
+     * @param int $column_start 0-based column number
+     * @param int $column_end 0-based column number
+     * @return bool
+     * @see ExcelSheet::clearPrintRepeats()
+     * @see ExcelSheet::setPrintRepeatRows()
+     */
+    public function setPrintRepeatCols($column_start, $column_end)
+    {
+    } // setPrintRepeatCols
+
+    /**
+     * Sets the color for the sheet's tab.
+     *
+     * @param int $color - one of the ExcelSheet::COLOR_* constants (optional, default=0)
+     * @return bool
+     */
+    public function setTabColor($color = 0)
+    {
+    } // setTabColor
+
+    /**
+     * Gets repeated columns on each page from colFirst to colLast. Returns false
+     * if repeated columns aren't found.
+     *
+     * @return bool|array with keys "col_start"(int) and "col_end"(int)
+     */
+    public function printRepeatCols()
+    {
+    } // printRepeatCols
+
+    /**
+     * Sets repeated rows on each page from row_start to row_end
+     *
+     * @param int $row_start 0-based row number
+     * @param int $row_end 0-based row number
+     * @return bool
+     * @see ExcelSheet::clearPrintRepeats()
+     * @see ExcelSheet::setPrintRepeatCols()
+     */
+    public function setPrintRepeatRows($row_start, $row_end)
+    {
+    } // setPrintRepeatRows
+
+    /**
+     * Gets repeated rows on each page from rowFirst to rowLast. Returns false
+     * if repeated rows aren't found.
+     *
+     * @return bool|array with keys "row_start"(int) and "row_end"(int)
+     */
+    public function printRepeatRows()
+    {
+    } // printRepeatRows
+
+    /**
+     * Protects or unprotects the worksheet
+     *
+     * @param bool $value
+     * @param string $password (optional, default="")
+     * @param int ExcelSheet::PROT_ALL (optional, default=ExcelSheet::PROT_DEFAULT)
+     * @return void
+     * @see ExcelSheet::protect()
+     */
+    public function setProtect($value, $password = '', $enhancedProtection = ExcelSheet::PROT_DEFAULT)
+    {
+    } // setProtect
+
+    /**
+     * Sets the right-to-left mode:
+     * 1 - the text is displayed in right-to-left mode,
+     * 0 - the text is displayed in left-to-right mode.
+     *
+     * @param int $mode
+     * @return void
+     */
+    public function setRightToLeft($mode)
+    {
+    } // setRightToLeft
+
+    /**
+     * Set the height of cells in a row
+     *
+     * @param int $row 0-based row number
+     * @param float $height
+     * @param ExcelFormat $format (optional, default=null)
+     * @param bool $hidden (optional, default=false)
+     * @return bool
+     * @see ExcelSheet::setColWidth()
+     * @see ExcelSheet::rowHeight()
+     * @see ExcelSheet::colWidth()
+     */
+    public function setRowHeight($row, $height, $format = null, $hidden = false)
+    {
+    } // setRowHeight
+
+    /**
+     * Hides row.
+     *
+     * @param int $row 0-based row number
+     * @param bool $hidden
+     * @return bool
+     */
+    public function setRowHidden($row, $hidden)
+    {
+    } // setRowHidden
+
+    /**
+     * Sets the first visible row and the leftmost visible column of the sheet.
+     *
+     * @param int $row
+     * @param int $column
+     * @return bool
+     */
+    public function setTopLeftView($row, $column)
+    {
+    } // setTopLeftView
+
+    /**
+     * Sets a flag that the sheet is centered vertically when printed
+     *
+     * @param bool $value
+     * @return void
+     * @see ExcelSheet::setHCenter()
+     */
+    public function setVCenter($value)
+    {
+    } // setVCenter
+
+    /**
+     * Sets the zoom level of the current view. 100 is the usual view
+     *
+     * @param int $value
+     * @return void
+     */
+    public function setZoom($value)
+    {
+    } // setZoom
+
+    /**
+     * Sets the scaling factor for printing (as a percentage)
+     *
+     * @param int $value
+     * @return void
+     */
+    public function setZoomPrint($value)
+    {
+    } // setZoomPrint
+
+    /**
+     * Gets the split information (position of frozen pane) in the sheet:
+     * row - vertical position of the split;
+     * col - horizontal position of the split.
+     *
+     * @return array
+     */
+    public function splitInfo()
+    {
+    } // splitInfo
+
+    /**
+     * Split sheet at indicated position
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @return void
+     */
+    public function splitSheet($row, $column)
+    {
+    } // splitSheet
+
+    /**
+     * Gets the table parameters by index.
+     *
+     * @param int $index (optional, default = 0)
+     * @return array with keys "name"(string), "row_first"(int), "col_first"(int), "row_last"(int), "col_last"(int), "header_row_count"(int) and "totals_row_count"(int)
+     */
+    public function table($index = 0)
+    {
+    } // table
+
+    /**
+     * Returns the number of tables in the sheet.
+     *
+     * @return int
+     */
+    public function tableSize()
+    {
+    } // tableSize
+
+    /**
+     * Returns whether the sheet is centered vertically when printed
+     *
+     * @return bool
+     * @see ExcelSheet::setVCenter()
+     * @see ExcelSheet::setHCenter()
+     * @see ExcelSheet::hcenter()
+     */
+    public function vcenter()
+    {
+    } // vcenter
+
+    /**
+     * Set/Remove vertical page break
+     *
+     * @param int $column 0-based column number
+     * @param bool $break
+     * @return bool
+     */
+    public function verPageBreak($column, $break)
+    {
+    } // verPageBreak
+
+    /**
+     * Write data into a cell
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @param mixed $data
+     * @param ExcelFormat $format (optional, default=null)
+     * @param int $data_type (optional, default=-1) One of ExcelFormat::AS_* constants
+     * @return bool
+     */
+    public function write($row, $column, $data, $format = null, $data_type = -1)
+    {
+    } // write
+
+    /**
+     * Write an array of values into a column
+     *
+     * @param int $column 0-based column number
+     * @param array $data
+     * @param int $row_start (optional, default=0)
+     * @param ExcelFormat $format (optional, default=null)
+     * @param int $data_type (optional, default=-1) One of ExcelFormat::AS_* constants
+     * @return bool
+     */
+    public function writeCol($column, $data, $row_start = 0, $format = null, $data_type = -1)
+    {
+    } // writeCol
+
+    /**
+     * Write comment to a cell (only for xls files)
+     *
+     * @param int $row 0-based row number
+     * @param int $column 0-based column number
+     * @param string $comment
+     * @param string $author
+     * @param int $width
+     * @param int $height
+     * @return void
+     */
+    public function writeComment($row, $column, $comment, $author, $width, $height)
+    {
+    } // writeComment
+
+    /**
+     * Writes error into the cell with specified format. If format equals 0 then format is ignored.
+     *
+     * @param int $row (optional, default = 0)
+     * @param int $col (optional, default = 0)
+     * @param int $error - one of ExcelSheet::ERRORTYPE_* constants  (optional, default = 0)
+     * @param ExcelFormat $format (optional, default = null)
+     * @return bool
+     */
+    public function writeError($row = 0, $col = 0, $error = 0, $format = null)
+    {
+    } // writeError
+
+    /**
+     * Write an array of values into a row
+     *
+     * @param int $row 0-based row number
+     * @param array $data
+     * @param int $column_start (optional, default=0)
+     * @param ExcelFormat $format (optional, default=null)
+     * @return bool
+     */
+    public function writeRow($row, $data, $column_start = 0, $format = null)
+    {
+    } // writeRow
 
     /**
      * Write formula with value into a cell
      *
-     * @since libXL 3.7.0.0
      * @param int $row 0-based row number
      * @param int $column 0-based column number
      * @param mixed $expr
      * @param mixed $value
      * @param ExcelFormat $format (optional, default=null)
      * @return bool
+     * @since libXL 3.7.0.0
      */
     public function writeFormula($row, $column, $expr, $value, $format = null)
     {
     } // writeFormula
 
-	/**
-	* Returns the zoom level of the current view as a percentage
-	*
-	* @return int
-	*/
-	public function zoom()
-	{
-	} // zoom
+    /**
+     * Returns the zoom level of the current view as a percentage
+     *
+     * @return int
+     */
+    public function zoom()
+    {
+    } // zoom
 
-	/**
-	* Returns the scaling factor for printing as a percentage
-	*
-	* @return int
-	*/
-	public function zoomPrint()
-	{
-	} // zoomPrint
+    /**
+     * Returns the scaling factor for printing as a percentage
+     *
+     * @return int
+     */
+    public function zoomPrint()
+    {
+    } // zoomPrint
 
 } // end ExcelSheet

--- a/docs/ExcelSheet.php
+++ b/docs/ExcelSheet.php
@@ -1442,6 +1442,18 @@ class ExcelSheet
     } // setTabColor
 
     /**
+     * Sets the RGB color for the sheet's tab.
+     *
+     * @param int $red
+     * @param int $green
+     * @param int $blue
+     * @return bool
+     */
+    public function setTabRgbColor($red, $green, $blue)
+    {
+    } // setTabRgbColor
+
+    /**
      * Gets repeated columns on each page from colFirst to colLast. Returns false
      * if repeated columns aren't found.
      *

--- a/excel.c
+++ b/excel.c
@@ -4957,8 +4957,28 @@ EXCEL_METHOD(Sheet, setTabColor)
 
 	SHEET_FROM_OBJECT(sheet, object);
 
-	// @todo check for XLSX format
 	xlSheetSetTabColor(sheet, color);
+	RETURN_TRUE;
+}
+/* }}} */
+
+/* {{{ proto long ExcelSheet::setTabRgbColor(int red, int green, int blue)
+	Sets the RGB color for the sheet's tab. */
+EXCEL_METHOD(Sheet, setTabRgbColor)
+{
+	zval *object = getThis();
+	SheetHandle sheet;
+	zend_long red = 0;
+	zend_long green = 0;
+	zend_long blue = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lll", &red, &green, &blue) == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	SHEET_FROM_OBJECT(sheet, object);
+
+	xlSheetSetTabRgbColor(sheet, red, green, blue);
 	RETURN_TRUE;
 }
 /* }}} */
@@ -6574,6 +6594,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_Sheet_setTabColor, 0, 0, 0)
 	ZEND_ARG_INFO(0, color)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_Sheet_setTabRgbColor, 0, 0, 3)
+	ZEND_ARG_INFO(0, red)
+	ZEND_ARG_INFO(0, green)
+	ZEND_ARG_INFO(0, blue)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_Sheet_table, 0, 0, 1)
 	ZEND_ARG_INFO(0, index)
 ZEND_END_ARG_INFO()
@@ -6932,6 +6958,7 @@ zend_function_entry excel_funcs_sheet[] = {
 #endif
 #if LIBXL_VERSION >= 0x03070000
 	EXCEL_ME(Sheet, setTabColor, arginfo_Sheet_setTabColor, 0)
+	EXCEL_ME(Sheet, setTabRgbColor, arginfo_Sheet_setTabRgbColor, 0)
 	EXCEL_ME(Sheet, applyFilter, arginfo_Sheet_applyFilter, 0)
 	EXCEL_ME(Sheet, autoFilter, arginfo_Sheet_autoFilter, 0)
 	EXCEL_ME(Sheet, removeFilter, arginfo_Sheet_removeFilter, 0)


### PR DESCRIPTION
**`ExcelSheet::writeFormula()`**

This enables creation of formula with arbitrary precalculated value to make preview and others show content instead of a "blank cell".

This effectively shall drop limitation in the README (https://github.com/doPhp/excel?tab=readme-ov-file#formulas-written-but-no-values-readable) that suggests to open file in Excel via COM and save back.

Implementation of the C methods:

- `xlSheetWriteFormulaNum`
- `xlSheetWriteFormulaStr`
- `xlSheetWriteFormulaBool`

**`ExcelSheet::setTabRgbColor()`**

Similarly to the existing method `ExcelSheet::setTabColor()`, this allows an arbitrary RGB color to be used for a sheet.

Implementation of the C method:

- `xlSheetSetTabRgbColor`

**Misc**

- Class documentation has been reformatted using PSR-12 (minor typo in comment fixed as well)
- Documentation has been extended to specify that methods `ExcelSheet::readComment()` and `ExcelSheet::writeComment()` only work for .xls files (not .xlsx). This is stated in the LibXL documentation but wasn't specified explicitly in the PHP documentation